### PR TITLE
Add Simplified Chinese localization and language settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ of `codex.cmd` or `codex.exe`.
   including credits, spend controls, earned resets, token activity, and model-specific limits
   when Codex returns them
 - System, light, and dark themes with five preset accent colors selected from Settings
+- Automatic Windows-language selection with English fallback, plus English and Simplified
+  Chinese overrides in Settings
 - A movable, always-on-top desktop widget and a compact label beside the notification area
 - Live task activity dots based on official local Codex lifecycle hooks
 - Automatic refresh every two minutes plus live rate-limit notifications
@@ -66,9 +68,9 @@ subscription percentage.
 
 Select the `−` button to move the widget to the taskbar. Right-click the taskbar label or
 tray icon to refresh, change the display mode, open Settings, check for updates, or exit.
-The Settings window opens from the gear button on the widget too. Theme, accent color,
-widget layout, displayed limit, and Start with Windows changes apply as soon as they are
-selected.
+The Settings window opens from the gear button on the widget too. Language, theme, accent
+color, widget layout, displayed limit, and Start with Windows changes apply as soon as they
+are selected.
 
 ## Activity dots
 
@@ -101,6 +103,7 @@ The application writes only under `%LOCALAPPDATA%\CodexUsageWidget`:
 - `displayed-limit.txt`: selected summary limit
 - `theme.txt`: system, light, or dark theme preference
 - `accent-palette.txt`: selected preset accent color
+- `language.txt`: system, English, or Simplified Chinese language preference
 - `logs\codex-usage-widget-YYYYMMDD.log`: diagnostic logs retained for 14 days
 
 The widget displays ChatGPT and Codex subscription limits. It does not display OpenAI API

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,9 @@ tests/CodexUsageWidget.Tests/ Unit tests for parsing, formatting and persistence
 11. `AppThemeController` applies the saved system, light, or dark theme plus the selected
     accent palette, and observes Windows theme changes without leaking registry access into
     view code.
-12. `MainWindow` remains a window-lifecycle shell while the Settings window coordinates
+12. `AppLanguageController` resolves the saved system, English, or Simplified Chinese
+    preference, while standard .NET resources and a notifying WPF binding refresh existing UI.
+13. `MainWindow` remains a window-lifecycle shell while the Settings window coordinates
     activity-hook setup plus immediate theme, accent, widget-layout, displayed-limit, and Windows
     startup preferences. Focused user controls render compact, detailed, and repeated limit-row
     content.

--- a/src/CodexUsageWidget/App.xaml.cs
+++ b/src/CodexUsageWidget/App.xaml.cs
@@ -7,6 +7,7 @@ using CodexUsageWidget.Infrastructure.Logging;
 using CodexUsageWidget.Infrastructure.Preview;
 using CodexUsageWidget.Infrastructure.Settings;
 using CodexUsageWidget.Infrastructure.Windows;
+using CodexUsageWidget.Localization;
 using CodexUsageWidget.Views;
 
 namespace CodexUsageWidget;
@@ -18,7 +19,19 @@ public partial class App : System.Windows.Application, IDisposable
     private FileLogger? _logger;
     private GlobalExceptionHandler? _exceptionHandler;
     private AppThemeController? _themeController;
+    private readonly AppLanguageController _languageController;
     private bool _disposed;
+
+    public App()
+        : this(new AppLanguageController(new LanguagePreferenceStore()))
+    {
+    }
+
+    public App(AppLanguageController languageController)
+    {
+        ArgumentNullException.ThrowIfNull(languageController);
+        _languageController = languageController;
+    }
 
     protected override void OnStartup(StartupEventArgs e)
     {
@@ -84,7 +97,8 @@ public partial class App : System.Windows.Application, IDisposable
                 new DisplayedLimitPreferenceStore(),
                 startupRegistrationService,
                 new TrayIconService(),
-                _themeController);
+                _themeController,
+                _languageController);
             MainWindow = window;
             activityMonitor.StartAsync().GetAwaiter().GetResult();
             window.Show();
@@ -100,8 +114,8 @@ public partial class App : System.Windows.Application, IDisposable
             activityMonitor?.DisposeAsync().AsTask().GetAwaiter().GetResult();
             _logger.LogError("Application startup failed.", ex);
             System.Windows.MessageBox.Show(
-                "Codex Usage Widget could not start. See the log under " + AppPaths.LogDirectory,
-                "Codex Usage Widget",
+                Strings.Format("App_StartupFailure", AppPaths.LogDirectory),
+                Strings.Get("App_Name"),
                 MessageBoxButton.OK,
                 MessageBoxImage.Error);
             Shutdown(-1);

--- a/src/CodexUsageWidget/Application/UsageMonitor.cs
+++ b/src/CodexUsageWidget/Application/UsageMonitor.cs
@@ -1,4 +1,5 @@
 using CodexUsageWidget.Domain;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Application;
 
@@ -67,7 +68,7 @@ public sealed class UsageMonitor : IAsyncDisposable
         }
         catch (OperationCanceledException) when (!_lifetime.IsCancellationRequested)
         {
-            RefreshFailed?.Invoke("Codex did not respond in time.");
+            RefreshFailed?.Invoke(Strings.Get("Error_ResponseTimeout"));
         }
         catch (Exception ex)
         {

--- a/src/CodexUsageWidget/Application/UsageTextFormatter.cs
+++ b/src/CodexUsageWidget/Application/UsageTextFormatter.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using CodexUsageWidget.Localization;
+
 namespace CodexUsageWidget.Application;
 
 public static class UsageTextFormatter
@@ -7,16 +10,17 @@ public static class UsageTextFormatter
         if (message.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("cannot find", StringComparison.OrdinalIgnoreCase))
         {
-            return "Codex CLI was not found on PATH.";
+            return Strings.Get("Error_CliNotFound");
         }
 
         if (message.Contains("login", StringComparison.OrdinalIgnoreCase) ||
             message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
         {
-            return "Run codex login, then refresh.";
+            return Strings.Get("Error_LoginRequired");
         }
 
-        return message.Length > 100 ? message[..100] + "…" : message;
+        var detail = message.Length > 100 ? message[..100] + "…" : message;
+        return Strings.Format("Error_Unexpected", detail);
     }
 
     public static string FormatReset(DateTimeOffset reset, DateTimeOffset? now = null)
@@ -24,15 +28,20 @@ public static class UsageTextFormatter
         var remaining = reset - (now ?? DateTimeOffset.Now);
         if (remaining <= TimeSpan.Zero)
         {
-            return "now";
+            return Strings.Get("Usage_ResetsNow");
         }
 
         if (remaining < TimeSpan.FromHours(24))
         {
-            return $"in {Math.Max(1, (int)Math.Ceiling(remaining.TotalHours))}h · {reset:HH:mm}";
+            return Strings.Format(
+                "Usage_ResetsInHours",
+                Math.Max(1, (int)Math.Ceiling(remaining.TotalHours)),
+                reset.ToString("HH:mm", CultureInfo.CurrentCulture));
         }
 
-        return $"{reset:ddd HH:mm}";
+        return Strings.Format(
+            "Usage_ResetsAt",
+            reset.ToString("ddd HH:mm", CultureInfo.CurrentCulture));
     }
 
     public static string ColorForRemaining(double remainingPercent) => remainingPercent switch

--- a/src/CodexUsageWidget/Infrastructure/AppPaths.cs
+++ b/src/CodexUsageWidget/Infrastructure/AppPaths.cs
@@ -18,6 +18,8 @@ public static class AppPaths
 
     public static string ThemePreferenceFile => Path.Combine(LocalDataDirectory, "theme.txt");
 
+    public static string LanguagePreferenceFile => Path.Combine(LocalDataDirectory, "language.txt");
+
     public static string AccentPaletteFile => Path.Combine(LocalDataDirectory, "accent-palette.txt");
 
     public static string LogDirectory => Path.Combine(LocalDataDirectory, "logs");

--- a/src/CodexUsageWidget/Infrastructure/Codex/Hooks/CodexActivityCommandLine.cs
+++ b/src/CodexUsageWidget/Infrastructure/Codex/Hooks/CodexActivityCommandLine.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using System.Text;
+using CodexUsageWidget.Infrastructure.Settings;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Infrastructure.Codex.Hooks;
 
@@ -28,6 +30,8 @@ public static class CodexActivityCommandLine
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        _ = new AppLanguageController(new LanguagePreferenceStore());
+
         using var input = new StreamReader(
             inputStream,
             Encoding.UTF8,
@@ -41,16 +45,33 @@ public static class CodexActivityCommandLine
             AutoFlush = true
         };
 
+        return await RunInteractiveAsync(
+            arguments,
+            input,
+            output,
+            new CodexHookConfigurationManager(),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<int> RunInteractiveAsync(
+        IReadOnlyList<string> arguments,
+        TextReader input,
+        TextWriter output,
+        CodexHookConfigurationManager manager,
+        CancellationToken cancellationToken = default)
+    {
         try
         {
-            var manager = new CodexHookConfigurationManager();
             var install = arguments[0] == InstallArgument;
             var plan = install
                 ? manager.PlanInstall()
                 : manager.PlanUninstall();
             if (plan.Error is not null)
             {
-                await output.WriteLineAsync(plan.Error).ConfigureAwait(false);
+                var error = plan.ErrorKind == CodexHookConfigurationErrorKind.HooksDisabled
+                    ? Strings.Get("Activity_HooksDisabledDescription")
+                    : Strings.Format("Activity_CommandFailure", plan.Error);
+                await output.WriteLineAsync(error).ConfigureAwait(false);
                 return 1;
             }
 
@@ -58,33 +79,36 @@ public static class CodexActivityCommandLine
             {
                 await output.WriteLineAsync(
                     install
-                        ? "Activity hooks are already installed."
-                        : "No matching activity hooks are installed.").ConfigureAwait(false);
+                        ? Strings.Get("Activity_CommandAlreadyInstalled")
+                        : Strings.Get("Activity_CommandNoMatching")).ConfigureAwait(false);
                 return 0;
             }
 
-            await output.WriteLineAsync("Proposed ~/.codex/hooks.json:").ConfigureAwait(false);
+            await output.WriteLineAsync(Strings.Get("Activity_CommandProposed"))
+                .ConfigureAwait(false);
             await output.WriteLineAsync(plan.ProposedContent).ConfigureAwait(false);
-            await output.WriteAsync("Apply this change? [y/N] ").ConfigureAwait(false);
+            await output.WriteAsync(Strings.Get("Activity_CommandApplyPrompt"))
+                .ConfigureAwait(false);
             var approval = await input.ReadLineAsync(cancellationToken).ConfigureAwait(false);
             if (!string.Equals(approval, "y", StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(approval, "yes", StringComparison.OrdinalIgnoreCase))
             {
-                await output.WriteLineAsync("No changes were made.").ConfigureAwait(false);
+                await output.WriteLineAsync(Strings.Get("Activity_CommandNoChanges"))
+                    .ConfigureAwait(false);
                 return 0;
             }
 
             manager.Apply(plan);
             await output.WriteLineAsync(
                 install
-                    ? "Activity hooks installed. Review and trust the exact definitions with /hooks."
-                    : "Matching activity hooks removed.").ConfigureAwait(false);
+                    ? Strings.Get("Activity_CommandInstalled")
+                    : Strings.Get("Activity_CommandRemoved")).ConfigureAwait(false);
             return 0;
         }
         catch (Exception ex) when (
             ex is IOException or UnauthorizedAccessException or InvalidOperationException)
         {
-            await output.WriteLineAsync($"Activity hook configuration failed: {ex.Message}")
+            await output.WriteLineAsync(Strings.Format("Activity_CommandFailure", ex.Message))
                 .ConfigureAwait(false);
             return 1;
         }

--- a/src/CodexUsageWidget/Infrastructure/Codex/Hooks/CodexActivityHookSetupService.cs
+++ b/src/CodexUsageWidget/Infrastructure/Codex/Hooks/CodexActivityHookSetupService.cs
@@ -70,7 +70,7 @@ public sealed class CodexActivityHookSetupService : IActivityHookSetupService
         {
             return new ActivityHookSetupStatus(
                 ActivityHookSetupState.InstalledStatusUnavailable,
-                $"Codex could not report hook trust status: {ex.Message}");
+                ex.Message);
         }
     }
 
@@ -123,8 +123,6 @@ public sealed class CodexActivityHookSetupService : IActivityHookSetupService
                 new ActivityHookSetupStatus(ActivityHookSetupState.Active),
             CodexHookTrustEvaluation.Modified =>
                 new ActivityHookSetupStatus(ActivityHookSetupState.Modified),
-            _ => new ActivityHookSetupStatus(
-                ActivityHookSetupState.InstalledStatusUnavailable,
-                "The hook definitions are installed, but Codex did not report all expected hooks.")
+            _ => new ActivityHookSetupStatus(ActivityHookSetupState.InstalledStatusUnavailable)
         };
 }

--- a/src/CodexUsageWidget/Infrastructure/Settings/LanguagePreference.cs
+++ b/src/CodexUsageWidget/Infrastructure/Settings/LanguagePreference.cs
@@ -1,0 +1,8 @@
+namespace CodexUsageWidget.Infrastructure.Settings;
+
+public enum LanguagePreference
+{
+    System,
+    English,
+    SimplifiedChinese
+}

--- a/src/CodexUsageWidget/Infrastructure/Settings/LanguagePreferenceResolver.cs
+++ b/src/CodexUsageWidget/Infrastructure/Settings/LanguagePreferenceResolver.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+
+namespace CodexUsageWidget.Infrastructure.Settings;
+
+public static class LanguagePreferenceResolver
+{
+    public static LanguagePreference Resolve(
+        LanguagePreference preference,
+        CultureInfo uiCulture) => preference switch
+        {
+            LanguagePreference.English => LanguagePreference.English,
+            LanguagePreference.SimplifiedChinese => LanguagePreference.SimplifiedChinese,
+            _ => IsSimplifiedChinese(uiCulture)
+                ? LanguagePreference.SimplifiedChinese
+                : LanguagePreference.English
+        };
+
+    private static bool IsSimplifiedChinese(CultureInfo culture)
+    {
+        for (var current = culture; !string.IsNullOrEmpty(current.Name); current = current.Parent)
+        {
+            if (string.Equals(current.Name, "zh-Hans", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/CodexUsageWidget/Infrastructure/Settings/LanguagePreferenceStore.cs
+++ b/src/CodexUsageWidget/Infrastructure/Settings/LanguagePreferenceStore.cs
@@ -1,0 +1,56 @@
+using System.IO;
+
+namespace CodexUsageWidget.Infrastructure.Settings;
+
+public sealed class LanguagePreferenceStore
+{
+    private readonly string _path;
+
+    public LanguagePreferenceStore(string? path = null)
+    {
+        _path = path ?? AppPaths.LanguagePreferenceFile;
+    }
+
+    public LanguagePreference Load()
+    {
+        try
+        {
+            return File.ReadAllText(_path).Trim().ToLowerInvariant() switch
+            {
+                "english" => LanguagePreference.English,
+                "simplified-chinese" => LanguagePreference.SimplifiedChinese,
+                _ => LanguagePreference.System
+            };
+        }
+        catch (IOException)
+        {
+            return LanguagePreference.System;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return LanguagePreference.System;
+        }
+    }
+
+    public void Save(LanguagePreference preference)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+            File.WriteAllText(
+                _path,
+                preference switch
+                {
+                    LanguagePreference.English => "english",
+                    LanguagePreference.SimplifiedChinese => "simplified-chinese",
+                    _ => "system"
+                });
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/CodexUsageWidget/Infrastructure/Windows/TrayIconService.cs
+++ b/src/CodexUsageWidget/Infrastructure/Windows/TrayIconService.cs
@@ -1,4 +1,5 @@
 using CodexUsageWidget.Infrastructure.Settings;
+using CodexUsageWidget.Localization;
 using Forms = System.Windows.Forms;
 
 namespace CodexUsageWidget.Infrastructure.Windows;
@@ -7,9 +8,16 @@ public sealed class TrayIconService : IDisposable
 {
     private readonly Forms.NotifyIcon _notifyIcon;
     private readonly Forms.ContextMenuStrip _menu;
+    private readonly Forms.ToolStripMenuItem _openItem;
+    private readonly Forms.ToolStripMenuItem _refreshItem;
+    private readonly Forms.ToolStripMenuItem _settingsItem;
+    private readonly Forms.ToolStripMenuItem _displayModeItem;
     private readonly Forms.ToolStripMenuItem _desktopWidgetModeItem;
     private readonly Forms.ToolStripMenuItem _taskbarIndicatorModeItem;
+    private readonly Forms.ToolStripMenuItem _updateItem;
+    private readonly Forms.ToolStripMenuItem _exitItem;
     private System.Drawing.Icon _currentIcon;
+    private double? _remainingPercent;
     private bool _disposed;
 
     public TrayIconService()
@@ -18,33 +26,47 @@ public sealed class TrayIconService : IDisposable
         {
             ShowItemToolTips = true
         };
-        menu.Items.Add("Open", null, (_, _) => OpenRequested?.Invoke(this, EventArgs.Empty));
-        menu.Items.Add("Refresh", null, (_, _) => RefreshRequested?.Invoke(this, EventArgs.Empty));
-        menu.Items.Add(
-            "Settings...",
+        _openItem = new Forms.ToolStripMenuItem(
+            null,
+            null,
+            (_, _) => OpenRequested?.Invoke(this, EventArgs.Empty));
+        _refreshItem = new Forms.ToolStripMenuItem(
+            null,
+            null,
+            (_, _) => RefreshRequested?.Invoke(this, EventArgs.Empty));
+        _settingsItem = new Forms.ToolStripMenuItem(
+            null,
             null,
             (_, _) => SettingsRequested?.Invoke(this, EventArgs.Empty));
+        menu.Items.Add(_openItem);
+        menu.Items.Add(_refreshItem);
+        menu.Items.Add(_settingsItem);
         menu.Items.Add(new Forms.ToolStripSeparator());
 
-        var displayModeMenu = new Forms.ToolStripMenuItem("Display mode");
+        _displayModeItem = new Forms.ToolStripMenuItem();
         _desktopWidgetModeItem = new Forms.ToolStripMenuItem(
-            "Desktop widget",
+            null,
             null,
             (_, _) => DesktopModeRequested?.Invoke(this, EventArgs.Empty));
         _taskbarIndicatorModeItem = new Forms.ToolStripMenuItem(
-            "Taskbar label",
+            null,
             null,
             (_, _) => TaskbarModeRequested?.Invoke(this, EventArgs.Empty));
-        displayModeMenu.DropDownItems.Add(_desktopWidgetModeItem);
-        displayModeMenu.DropDownItems.Add(_taskbarIndicatorModeItem);
-        menu.Items.Add(displayModeMenu);
+        _displayModeItem.DropDownItems.Add(_desktopWidgetModeItem);
+        _displayModeItem.DropDownItems.Add(_taskbarIndicatorModeItem);
+        menu.Items.Add(_displayModeItem);
 
-        menu.Items.Add(
-            "Check for updates...",
+        _updateItem = new Forms.ToolStripMenuItem(
+            null,
             null,
             (_, _) => UpdateCheckRequested?.Invoke(this, EventArgs.Empty));
+        menu.Items.Add(_updateItem);
         menu.Items.Add(new Forms.ToolStripSeparator());
-        menu.Items.Add("Exit", null, (_, _) => ExitRequested?.Invoke(this, EventArgs.Empty));
+        _exitItem = new Forms.ToolStripMenuItem(
+            null,
+            null,
+            (_, _) => ExitRequested?.Invoke(this, EventArgs.Empty));
+        menu.Items.Add(_exitItem);
 
         _currentIcon = UsageIconFactory.Create(null);
         _menu = menu;
@@ -56,6 +78,8 @@ public sealed class TrayIconService : IDisposable
             ContextMenuStrip = menu
         };
         _notifyIcon.MouseClick += NotifyIconOnMouseClick;
+        Strings.Current.PropertyChanged += StringsOnPropertyChanged;
+        RefreshLocalizedText();
         SetTheme(EffectiveTheme.Dark);
     }
 
@@ -114,15 +138,37 @@ public sealed class TrayIconService : IDisposable
 
     public void UpdateUsage(double? remainingPercent)
     {
+        _remainingPercent = remainingPercent;
         _notifyIcon.Text = remainingPercent is null
-            ? "Codex Usage · unavailable"
-            : $"Codex · {Math.Round(remainingPercent.Value):0}% remaining";
+            ? Strings.Get("Tray_Unavailable")
+            : Strings.Format("Tray_Remaining", Math.Round(remainingPercent.Value));
 
         var nextIcon = UsageIconFactory.Create(remainingPercent);
         var previousIcon = _currentIcon;
         _currentIcon = nextIcon;
         _notifyIcon.Icon = nextIcon;
         previousIcon.Dispose();
+    }
+
+    private void StringsOnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == "Item[]")
+        {
+            RefreshLocalizedText();
+        }
+    }
+
+    private void RefreshLocalizedText()
+    {
+        _openItem.Text = Strings.Get("Tray_Open");
+        _refreshItem.Text = Strings.Get("Common_Refresh");
+        _settingsItem.Text = Strings.Get("Tray_Settings");
+        _displayModeItem.Text = Strings.Get("Tray_DisplayMode");
+        _desktopWidgetModeItem.Text = Strings.Get("Tray_DesktopWidget");
+        _taskbarIndicatorModeItem.Text = Strings.Get("Tray_TaskbarLabel");
+        _updateItem.Text = Strings.Get("Tray_CheckUpdates");
+        _exitItem.Text = Strings.Get("Common_Exit");
+        UpdateUsage(_remainingPercent);
     }
 
     private void NotifyIconOnMouseClick(object? sender, Forms.MouseEventArgs e)
@@ -141,6 +187,7 @@ public sealed class TrayIconService : IDisposable
         }
 
         _disposed = true;
+        Strings.Current.PropertyChanged -= StringsOnPropertyChanged;
         _notifyIcon.MouseClick -= NotifyIconOnMouseClick;
         _notifyIcon.Visible = false;
         _notifyIcon.ContextMenuStrip?.Dispose();

--- a/src/CodexUsageWidget/Localization/AppLanguageController.cs
+++ b/src/CodexUsageWidget/Localization/AppLanguageController.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+using CodexUsageWidget.Infrastructure.Settings;
+
+namespace CodexUsageWidget.Localization;
+
+public sealed class AppLanguageController
+{
+    private readonly LanguagePreferenceStore? _store;
+    private readonly CultureInfo _systemUiCulture;
+
+    public AppLanguageController(
+        LanguagePreferenceStore store,
+        CultureInfo? systemUiCulture = null)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        _store = store;
+        _systemUiCulture = systemUiCulture ?? CultureInfo.CurrentUICulture;
+        Preference = store.Load();
+        ApplyPreference();
+    }
+
+    public AppLanguageController(
+        LanguagePreference preference,
+        CultureInfo? systemUiCulture = null)
+    {
+        _systemUiCulture = systemUiCulture ?? CultureInfo.CurrentUICulture;
+        Preference = preference;
+        ApplyPreference();
+    }
+
+    public LanguagePreference Preference { get; private set; }
+
+    public LanguagePreference EffectiveLanguage =>
+        LanguagePreferenceResolver.Resolve(Preference, _systemUiCulture);
+
+    public void SetPreference(LanguagePreference preference)
+    {
+        Preference = preference;
+        _store?.Save(preference);
+        ApplyPreference();
+    }
+
+    private void ApplyPreference()
+    {
+        var cultureName = EffectiveLanguage == LanguagePreference.SimplifiedChinese
+            ? "zh-CN"
+            : "en-US";
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo(cultureName));
+    }
+}

--- a/src/CodexUsageWidget/Localization/Strings.cs
+++ b/src/CodexUsageWidget/Localization/Strings.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Resources;
+
+namespace CodexUsageWidget.Localization;
+
+public sealed class Strings : INotifyPropertyChanged
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "CodexUsageWidget.Resources.Strings",
+        typeof(Strings).Assembly);
+    private CultureInfo _culture = CultureInfo.GetCultureInfo("en-US");
+
+    private Strings()
+    {
+    }
+
+    public static Strings Current { get; } = new();
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string this[string key] => Get(key);
+
+    public CultureInfo Culture => _culture;
+
+    public static string Get(string key) =>
+        ResourceManager.GetString(key, Current._culture) ?? key;
+
+    public static string GetForCulture(string key, CultureInfo culture) =>
+        ResourceManager.GetString(key, culture) ?? key;
+
+    public static string Format(string key, params object?[] arguments) =>
+        string.Format(CultureInfo.CurrentCulture, Get(key), arguments);
+
+    public static string FormatForCulture(
+        CultureInfo culture,
+        string key,
+        params object?[] arguments) =>
+        string.Format(culture, GetForCulture(key, culture), arguments);
+
+    public void SetCulture(CultureInfo culture)
+    {
+        ArgumentNullException.ThrowIfNull(culture);
+        var changed = !string.Equals(
+            _culture.Name,
+            culture.Name,
+            StringComparison.OrdinalIgnoreCase);
+        _culture = culture;
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        if (changed)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+        }
+    }
+}

--- a/src/CodexUsageWidget/Localization/Strings.cs
+++ b/src/CodexUsageWidget/Localization/Strings.cs
@@ -46,6 +46,8 @@ public sealed class Strings : INotifyPropertyChanged
             culture.Name,
             StringComparison.OrdinalIgnoreCase);
         _culture = culture;
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
         CultureInfo.CurrentUICulture = culture;
         CultureInfo.DefaultThreadCurrentUICulture = culture;
         if (changed)

--- a/src/CodexUsageWidget/Localization/UsageLabelLocalizer.cs
+++ b/src/CodexUsageWidget/Localization/UsageLabelLocalizer.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace CodexUsageWidget.Localization;
+
+public static class UsageLabelLocalizer
+{
+    public static string Localize(string label, CultureInfo? culture = null)
+    {
+        culture ??= Strings.Current.Culture;
+        return label switch
+        {
+            "Weekly limit" => Strings.GetForCulture("Usage_WeeklyLimit", culture),
+            "Primary limit" => Strings.GetForCulture("Usage_PrimaryLimit", culture),
+            "Secondary limit" => Strings.GetForCulture("Usage_SecondaryLimit", culture),
+            _ when TryReadDuration(label, 'd', out var days) =>
+                Strings.FormatForCulture(culture, "Usage_DayLimit", days),
+            _ when TryReadDuration(label, 'h', out var hours) =>
+                Strings.FormatForCulture(culture, "Usage_HourLimit", hours),
+            _ when TryReadDuration(label, 'm', out var minutes) =>
+                Strings.FormatForCulture(culture, "Usage_MinuteLimit", minutes),
+            _ => label
+        };
+    }
+
+    private static bool TryReadDuration(string label, char unit, out long value)
+    {
+        value = 0;
+        var suffix = $"{unit} limit";
+        return label.EndsWith(suffix, StringComparison.Ordinal) &&
+            long.TryParse(
+                label.AsSpan(0, label.Length - suffix.Length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out value);
+    }
+}

--- a/src/CodexUsageWidget/Program.cs
+++ b/src/CodexUsageWidget/Program.cs
@@ -4,7 +4,9 @@ using System.IO;
 using System.Security;
 using CodexUsageWidget.Infrastructure;
 using CodexUsageWidget.Infrastructure.Codex.Hooks;
+using CodexUsageWidget.Infrastructure.Settings;
 using CodexUsageWidget.Infrastructure.Windows;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget;
 
@@ -28,9 +30,10 @@ internal static class Program
         catch (Exception ex) when (
             ex is IOException or UnauthorizedAccessException or SecurityException or Win32Exception)
         {
+            _ = new AppLanguageController(new LanguagePreferenceStore());
             System.Windows.MessageBox.Show(
-                "Codex Usage Widget could not install itself for the current user. " + ex.Message,
-                "Codex Usage Widget",
+                Strings.Format("App_InstallFailure", ex.Message),
+                Strings.Get("App_Name"),
                 System.Windows.MessageBoxButton.OK,
                 System.Windows.MessageBoxImage.Error);
             return -1;

--- a/src/CodexUsageWidget/Properties/AssemblyInfo.cs
+++ b/src/CodexUsageWidget/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CodexUsageWidget.Tests")]

--- a/src/CodexUsageWidget/Resources/Strings.resx
+++ b/src/CodexUsageWidget/Resources/Strings.resx
@@ -126,9 +126,9 @@
   <data name="Settings_DisplayedLimit_MostConstrainedAutomation" xml:space="preserve"><value>Display most constrained limit</value></data>
   <data name="Settings_SectionFeatures" xml:space="preserve"><value>FEATURES</value></data>
   <data name="Settings_Language_Title" xml:space="preserve"><value>Language</value></data>
-  <data name="Settings_Language_Description" xml:space="preserve"><value>Follow the Windows display language or always use one language.</value></data>
+  <data name="Settings_Language_Description" xml:space="preserve"><value>Choose English or Simplified Chinese, or let Windows decide.</value></data>
   <data name="Settings_Language_System" xml:space="preserve"><value>Use Windows setting</value></data>
-  <data name="Settings_Language_SystemDescription" xml:space="preserve"><value>Uses Simplified Chinese when supported; otherwise English</value></data>
+  <data name="Settings_Language_SystemDescription" xml:space="preserve"><value>Uses Simplified Chinese when Windows does. Otherwise, uses English.</value></data>
   <data name="Settings_Language_SystemAutomation" xml:space="preserve"><value>Use Windows language</value></data>
   <data name="Settings_Language_English" xml:space="preserve"><value>English</value></data>
   <data name="Settings_Language_EnglishDescription" xml:space="preserve"><value>Always use English</value></data>
@@ -176,6 +176,14 @@
   <data name="Activity_ReviewInstallDescription" xml:space="preserve"><value>The widget will write this exact ~/.codex/hooks.json content. Existing hooks and unknown fields are preserved.</value></data>
   <data name="Activity_ReviewRemoveDescription" xml:space="preserve"><value>Only handlers that exactly match this widget executable will be removed. Other hook definitions are preserved.</value></data>
   <data name="Activity_InstallHooks" xml:space="preserve"><value>Install hooks</value></data>
+  <data name="Activity_CommandAlreadyInstalled" xml:space="preserve"><value>Activity hooks are already installed.</value></data>
+  <data name="Activity_CommandNoMatching" xml:space="preserve"><value>No matching activity hooks are installed.</value></data>
+  <data name="Activity_CommandProposed" xml:space="preserve"><value>Proposed ~/.codex/hooks.json:</value></data>
+  <data name="Activity_CommandApplyPrompt" xml:space="preserve"><value>Apply this change? [y/N] </value></data>
+  <data name="Activity_CommandNoChanges" xml:space="preserve"><value>No changes were made.</value></data>
+  <data name="Activity_CommandInstalled" xml:space="preserve"><value>Activity hooks installed. Review and trust the exact definitions with /hooks.</value></data>
+  <data name="Activity_CommandRemoved" xml:space="preserve"><value>Matching activity hooks removed.</value></data>
+  <data name="Activity_CommandFailure" xml:space="preserve"><value>Activity hook configuration failed: {0}</value></data>
   <data name="Tray_Open" xml:space="preserve"><value>Open</value></data>
   <data name="Tray_Settings" xml:space="preserve"><value>Settings...</value></data>
   <data name="Tray_DisplayMode" xml:space="preserve"><value>Display mode</value></data>

--- a/src/CodexUsageWidget/Resources/Strings.resx
+++ b/src/CodexUsageWidget/Resources/Strings.resx
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="App_Name" xml:space="preserve"><value>Codex Usage Widget</value></data>
+  <data name="App_MainTitle" xml:space="preserve"><value>Codex Usage</value></data>
+  <data name="App_InstallFailure" xml:space="preserve"><value>Codex Usage Widget could not install itself for the current user. {0}</value></data>
+  <data name="App_StartupFailure" xml:space="preserve"><value>Codex Usage Widget could not start. See the log under {0}</value></data>
+  <data name="Common_Available" xml:space="preserve"><value>Available</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Common_CheckAgain" xml:space="preserve"><value>Check again</value></data>
+  <data name="Common_Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Common_Exit" xml:space="preserve"><value>Exit</value></data>
+  <data name="Common_NoneAvailable" xml:space="preserve"><value>None available</value></data>
+  <data name="Common_Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="Common_Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Common_Unlimited" xml:space="preserve"><value>Unlimited</value></data>
+  <data name="Main_ActivityRunning" xml:space="preserve"><value>Codex task is running</value></data>
+  <data name="Main_RefreshUsage" xml:space="preserve"><value>Refresh usage</value></data>
+  <data name="Main_ShowCompact" xml:space="preserve"><value>Show compact view</value></data>
+  <data name="Main_ShowDetails" xml:space="preserve"><value>Show details</value></data>
+  <data name="Main_ToggleLayout" xml:space="preserve"><value>Toggle widget layout</value></data>
+  <data name="Main_UseTaskbarLabel" xml:space="preserve"><value>Use taskbar label</value></data>
+  <data name="Main_StartupPreferenceError" xml:space="preserve"><value>The Windows startup preference could not be updated.</value></data>
+  <data name="Main_UpdateOpenError" xml:space="preserve"><value>Windows could not open the widget release page.</value></data>
+  <data name="Status_Connecting" xml:space="preserve"><value>Connecting…</value></data>
+  <data name="Status_WaitingForCodex" xml:space="preserve"><value>Waiting for Codex</value></data>
+  <data name="Status_LocalWaiting" xml:space="preserve"><value>Local only · waiting for sync</value></data>
+  <data name="Status_Offline" xml:space="preserve"><value>Offline</value></data>
+  <data name="Status_LocalRetry" xml:space="preserve"><value>Local only · select refresh to retry</value></data>
+  <data name="Status_Syncing" xml:space="preserve"><value>Syncing…</value></data>
+  <data name="Status_LivePlan" xml:space="preserve"><value>Live · {0}</value></data>
+  <data name="Status_HeadlineRemaining" xml:space="preserve"><value>{0} remaining</value></data>
+  <data name="Status_LocalUpdated" xml:space="preserve"><value>Local only · updated {0}</value></data>
+  <data name="Status_NoLimits" xml:space="preserve"><value>No subscription limits returned. Run codex login first.</value></data>
+  <data name="Error_CliNotFound" xml:space="preserve"><value>Codex CLI was not found on PATH.</value></data>
+  <data name="Error_LoginRequired" xml:space="preserve"><value>Run codex login, then refresh.</value></data>
+  <data name="Error_ResponseTimeout" xml:space="preserve"><value>Codex did not respond in time.</value></data>
+  <data name="Error_Unexpected" xml:space="preserve"><value>Codex usage could not be read. {0}</value></data>
+  <data name="Warning_WorkspaceCreditsDepleted" xml:space="preserve"><value>Workspace credits are depleted.</value></data>
+  <data name="Warning_WorkspaceUsageLimitReached" xml:space="preserve"><value>Workspace usage limit reached.</value></data>
+  <data name="Warning_UsageLimitReached" xml:space="preserve"><value>Codex usage limit reached.</value></data>
+  <data name="Warning_SpendControlReached" xml:space="preserve"><value>Individual spend control reached.</value></data>
+  <data name="Usage_FiveHourLimit" xml:space="preserve"><value>5h limit</value></data>
+  <data name="Usage_WeeklyLimit" xml:space="preserve"><value>Weekly limit</value></data>
+  <data name="Usage_DayLimit" xml:space="preserve"><value>{0}d limit</value></data>
+  <data name="Usage_HourLimit" xml:space="preserve"><value>{0}h limit</value></data>
+  <data name="Usage_MinuteLimit" xml:space="preserve"><value>{0}m limit</value></data>
+  <data name="Usage_PrimaryLimit" xml:space="preserve"><value>Primary limit</value></data>
+  <data name="Usage_SecondaryLimit" xml:space="preserve"><value>Secondary limit</value></data>
+  <data name="Usage_UsedPercent" xml:space="preserve"><value>{0}% used</value></data>
+  <data name="Usage_RemainingPercent" xml:space="preserve"><value>{0}% remaining</value></data>
+  <data name="Usage_ResetUnavailable" xml:space="preserve"><value>Reset time unavailable</value></data>
+  <data name="Usage_ResetsNow" xml:space="preserve"><value>Resets now</value></data>
+  <data name="Usage_ResetsInHours" xml:space="preserve"><value>Resets in {0}h · {1}</value></data>
+  <data name="Usage_ResetsAt" xml:space="preserve"><value>Resets {0}</value></data>
+  <data name="Usage_CreditsRemaining" xml:space="preserve"><value>{0} remaining</value></data>
+  <data name="Usage_ChatGptCredits" xml:space="preserve"><value>ChatGPT credits</value></data>
+  <data name="Usage_IndividualSpendLimit" xml:space="preserve"><value>Individual spend limit</value></data>
+  <data name="Usage_SpendLimitValue" xml:space="preserve"><value>{0} of {1} · {2}% remaining</value></data>
+  <data name="Usage_SpendLimitResets" xml:space="preserve"><value>Spend limit resets</value></data>
+  <data name="Usage_RateLimitResets" xml:space="preserve"><value>Rate-limit resets</value></data>
+  <data name="Usage_CountAvailable" xml:space="preserve"><value>{0} available</value></data>
+  <data name="Usage_SectionOverview" xml:space="preserve"><value>OVERVIEW</value></data>
+  <data name="Usage_SectionCreditsLimits" xml:space="preserve"><value>CREDITS &amp; LIMITS</value></data>
+  <data name="Usage_SectionTokenActivity" xml:space="preserve"><value>TOKEN ACTIVITY</value></data>
+  <data name="Usage_NotQuotaConsumption" xml:space="preserve"><value>Not quota consumption</value></data>
+  <data name="Usage_SectionModelLimits" xml:space="preserve"><value>MODEL-SPECIFIC LIMITS</value></data>
+  <data name="Token_Lifetime" xml:space="preserve"><value>Lifetime tokens</value></data>
+  <data name="Token_PeakDaily" xml:space="preserve"><value>Peak daily tokens</value></data>
+  <data name="Token_LongestTurn" xml:space="preserve"><value>Longest turn</value></data>
+  <data name="Token_CurrentStreak" xml:space="preserve"><value>Current streak</value></data>
+  <data name="Token_LongestStreak" xml:space="preserve"><value>Longest streak</value></data>
+  <data name="Token_Days" xml:space="preserve"><value>{0} days</value></data>
+  <data name="Token_Count" xml:space="preserve"><value>{0} tokens</value></data>
+  <data name="Token_ChartPeak" xml:space="preserve"><value>{0}% of chart peak</value></data>
+  <data name="Token_DurationHoursMinutes" xml:space="preserve"><value>{0}h {1}m</value></data>
+  <data name="Token_DurationMinutes" xml:space="preserve"><value>{0}m</value></data>
+  <data name="Settings_Description" xml:space="preserve"><value>Choose how Codex Usage Widget looks and behaves.</value></data>
+  <data name="Settings_SectionGeneral" xml:space="preserve"><value>GENERAL</value></data>
+  <data name="Settings_StartWithWindows" xml:space="preserve"><value>Start with Windows</value></data>
+  <data name="Settings_StartWithWindowsDescription" xml:space="preserve"><value>Launch the widget when you sign in</value></data>
+  <data name="Settings_Theme_Title" xml:space="preserve"><value>Theme</value></data>
+  <data name="Settings_Theme_Description" xml:space="preserve"><value>Use the Windows setting or keep the widget in one theme.</value></data>
+  <data name="Settings_Theme_System" xml:space="preserve"><value>Use Windows setting</value></data>
+  <data name="Settings_Theme_SystemDescription" xml:space="preserve"><value>Changes with your Windows app theme</value></data>
+  <data name="Settings_Theme_SystemAutomation" xml:space="preserve"><value>Use Windows theme</value></data>
+  <data name="Settings_Theme_Light" xml:space="preserve"><value>Light</value></data>
+  <data name="Settings_Theme_LightDescription" xml:space="preserve"><value>Bright surfaces with dark text</value></data>
+  <data name="Settings_Theme_LightAutomation" xml:space="preserve"><value>Use light theme</value></data>
+  <data name="Settings_Theme_Dark" xml:space="preserve"><value>Dark</value></data>
+  <data name="Settings_Theme_DarkDescription" xml:space="preserve"><value>Dark surfaces with light text</value></data>
+  <data name="Settings_Theme_DarkAutomation" xml:space="preserve"><value>Use dark theme</value></data>
+  <data name="Settings_Accent_Title" xml:space="preserve"><value>Accent</value></data>
+  <data name="Settings_Accent_Blue" xml:space="preserve"><value>Blue</value></data>
+  <data name="Settings_Accent_Violet" xml:space="preserve"><value>Violet</value></data>
+  <data name="Settings_Accent_Teal" xml:space="preserve"><value>Teal</value></data>
+  <data name="Settings_Accent_Emerald" xml:space="preserve"><value>Emerald</value></data>
+  <data name="Settings_Accent_Pink" xml:space="preserve"><value>Pink</value></data>
+  <data name="Settings_Accent_Automation" xml:space="preserve"><value>Use {0} accent</value></data>
+  <data name="Settings_Accent_BlueAutomation" xml:space="preserve"><value>Use blue accent</value></data>
+  <data name="Settings_Accent_VioletAutomation" xml:space="preserve"><value>Use violet accent</value></data>
+  <data name="Settings_Accent_TealAutomation" xml:space="preserve"><value>Use teal accent</value></data>
+  <data name="Settings_Accent_EmeraldAutomation" xml:space="preserve"><value>Use emerald accent</value></data>
+  <data name="Settings_Accent_PinkAutomation" xml:space="preserve"><value>Use pink accent</value></data>
+  <data name="Settings_Layout_Title" xml:space="preserve"><value>Widget layout</value></data>
+  <data name="Settings_Layout_Description" xml:space="preserve"><value>Choose how much information the desktop widget shows.</value></data>
+  <data name="Settings_Layout_Compact" xml:space="preserve"><value>Compact</value></data>
+  <data name="Settings_Layout_CompactDescription" xml:space="preserve"><value>Summary at a glance</value></data>
+  <data name="Settings_Layout_CompactAutomation" xml:space="preserve"><value>Use compact widget layout</value></data>
+  <data name="Settings_Layout_Detailed" xml:space="preserve"><value>Detailed</value></data>
+  <data name="Settings_Layout_DetailedDescription" xml:space="preserve"><value>Full usage breakdown</value></data>
+  <data name="Settings_Layout_DetailedAutomation" xml:space="preserve"><value>Use detailed widget layout</value></data>
+  <data name="Settings_SectionUsage" xml:space="preserve"><value>USAGE</value></data>
+  <data name="Settings_DisplayedLimit_Title" xml:space="preserve"><value>Displayed limit</value></data>
+  <data name="Settings_DisplayedLimit_Description" xml:space="preserve"><value>Choose the limit shown in the widget, taskbar label, and tray icon.</value></data>
+  <data name="Settings_DisplayedLimit_FiveHourDescription" xml:space="preserve"><value>Show the global five-hour usage window</value></data>
+  <data name="Settings_DisplayedLimit_FiveHourAutomation" xml:space="preserve"><value>Display 5-hour limit</value></data>
+  <data name="Settings_DisplayedLimit_FiveHourUnavailable" xml:space="preserve"><value>Codex did not return a global 5h limit for this account.</value></data>
+  <data name="Settings_DisplayedLimit_WeeklyDescription" xml:space="preserve"><value>Show the global weekly usage window</value></data>
+  <data name="Settings_DisplayedLimit_WeeklyAutomation" xml:space="preserve"><value>Display weekly limit</value></data>
+  <data name="Settings_DisplayedLimit_MostConstrained" xml:space="preserve"><value>Most constrained</value></data>
+  <data name="Settings_DisplayedLimit_MostConstrainedDescription" xml:space="preserve"><value>Show whichever available limit has the least remaining</value></data>
+  <data name="Settings_DisplayedLimit_MostConstrainedAutomation" xml:space="preserve"><value>Display most constrained limit</value></data>
+  <data name="Settings_SectionFeatures" xml:space="preserve"><value>FEATURES</value></data>
+  <data name="Settings_Language_Title" xml:space="preserve"><value>Language</value></data>
+  <data name="Settings_Language_Description" xml:space="preserve"><value>Follow the Windows display language or always use one language.</value></data>
+  <data name="Settings_Language_System" xml:space="preserve"><value>Use Windows setting</value></data>
+  <data name="Settings_Language_SystemDescription" xml:space="preserve"><value>Uses Simplified Chinese when supported; otherwise English</value></data>
+  <data name="Settings_Language_SystemAutomation" xml:space="preserve"><value>Use Windows language</value></data>
+  <data name="Settings_Language_English" xml:space="preserve"><value>English</value></data>
+  <data name="Settings_Language_EnglishDescription" xml:space="preserve"><value>Always use English</value></data>
+  <data name="Settings_Language_EnglishAutomation" xml:space="preserve"><value>Use English</value></data>
+  <data name="Settings_Language_Chinese" xml:space="preserve"><value>简体中文</value></data>
+  <data name="Settings_Language_ChineseDescription" xml:space="preserve"><value>Always use Simplified Chinese</value></data>
+  <data name="Settings_Language_ChineseAutomation" xml:space="preserve"><value>Use Simplified Chinese</value></data>
+  <data name="Activity_Title" xml:space="preserve"><value>Codex activity</value></data>
+  <data name="Activity_Description" xml:space="preserve"><value>Show when a local Codex turn is running</value></data>
+  <data name="Activity_Privacy" xml:space="preserve"><value>Privacy: only activity type, session ID, and turn ID travel through a local user-only pipe. Prompts and responses never leave Codex.</value></data>
+  <data name="Activity_RemoveHooks" xml:space="preserve"><value>Remove hooks</value></data>
+  <data name="Activity_CopyHooksTooltip" xml:space="preserve"><value>Copies /hooks and opens Codex</value></data>
+  <data name="Activity_Checking" xml:space="preserve"><value>Checking Codex…</value></data>
+  <data name="Activity_CheckingDescription" xml:space="preserve"><value>Reading the local hook configuration and Codex trust status.</value></data>
+  <data name="Activity_OpenInCodex" xml:space="preserve"><value>Open in Codex</value></data>
+  <data name="Activity_ReviewHooks" xml:space="preserve"><value>Review hooks</value></data>
+  <data name="Activity_SetupRequired" xml:space="preserve"><value>Setup required</value></data>
+  <data name="Activity_SetupRequiredDescription" xml:space="preserve"><value>Install three local lifecycle hooks to animate the taskbar dots while Codex works. You can review the exact hooks.json change before it is written.</value></data>
+  <data name="Activity_UpdateAvailable" xml:space="preserve"><value>Update available</value></data>
+  <data name="Activity_UpdateDescription" xml:space="preserve"><value>Activity handlers from an older widget version are installed. Update them to the faster, path-independent bridge after reviewing the exact change.</value></data>
+  <data name="Activity_ReviewUpdate" xml:space="preserve"><value>Review update</value></data>
+  <data name="Activity_OneStepLeft" xml:space="preserve"><value>One step left</value></data>
+  <data name="Activity_ApprovalDescription" xml:space="preserve"><value>Hooks are installed. Approve their exact definitions once in Codex before they can run.</value></data>
+  <data name="Activity_ApproveInCodex" xml:space="preserve"><value>Approve in Codex</value></data>
+  <data name="Activity_Ready" xml:space="preserve"><value>Activity dots are ready</value></data>
+  <data name="Activity_ReadyDescription" xml:space="preserve"><value>All three hooks are installed and trusted.</value></data>
+  <data name="Activity_ReviewRequired" xml:space="preserve"><value>Review required</value></data>
+  <data name="Activity_ModifiedDescription" xml:space="preserve"><value>Codex paused the changed definitions. Review them again before activity reporting resumes.</value></data>
+  <data name="Activity_ReviewInCodex" xml:space="preserve"><value>Review in Codex</value></data>
+  <data name="Activity_HooksDisabled" xml:space="preserve"><value>Hooks are disabled in Codex</value></data>
+  <data name="Activity_HooksDisabledDescription" xml:space="preserve"><value>Set hooks = true in the [features] section of your Codex config before installing.</value></data>
+  <data name="Activity_StatusUnavailable" xml:space="preserve"><value>Installed · status unavailable</value></data>
+  <data name="Activity_StatusUnavailableDescription" xml:space="preserve"><value>Hooks are installed, but their trust status could not be verified.</value></data>
+  <data name="Activity_StatusUnavailableWithDetail" xml:space="preserve"><value>Hooks are installed, but Codex could not report their trust status. {0}</value></data>
+  <data name="Activity_OpenHooksInCodex" xml:space="preserve"><value>Open hooks in Codex</value></data>
+  <data name="Activity_SetupUnavailable" xml:space="preserve"><value>Setup unavailable</value></data>
+  <data name="Activity_SetupUnavailableDescription" xml:space="preserve"><value>The activity hook configuration could not be read.</value></data>
+  <data name="Activity_SetupErrorDetail" xml:space="preserve"><value>The activity hook setup could not be completed. {0}</value></data>
+  <data name="Activity_StatusTimeout" xml:space="preserve"><value>Codex did not report hook status in time. Check that the CLI is available, then try again.</value></data>
+  <data name="Activity_CodexOpenCopied" xml:space="preserve"><value>Codex is open. Paste /hooks and approve the three definitions. Status refreshes when you return here.</value></data>
+  <data name="Activity_CodexOpenType" xml:space="preserve"><value>Codex is open. Type /hooks and approve the three definitions. Status refreshes when you return here.</value></data>
+  <data name="Activity_ReviewTitle" xml:space="preserve"><value>Review Codex activity hooks</value></data>
+  <data name="Activity_ReviewInstallHeading" xml:space="preserve"><value>Review activity hook installation</value></data>
+  <data name="Activity_ReviewRemoveHeading" xml:space="preserve"><value>Review activity hook removal</value></data>
+  <data name="Activity_ReviewInstallDescription" xml:space="preserve"><value>The widget will write this exact ~/.codex/hooks.json content. Existing hooks and unknown fields are preserved.</value></data>
+  <data name="Activity_ReviewRemoveDescription" xml:space="preserve"><value>Only handlers that exactly match this widget executable will be removed. Other hook definitions are preserved.</value></data>
+  <data name="Activity_InstallHooks" xml:space="preserve"><value>Install hooks</value></data>
+  <data name="Tray_Open" xml:space="preserve"><value>Open</value></data>
+  <data name="Tray_Settings" xml:space="preserve"><value>Settings...</value></data>
+  <data name="Tray_DisplayMode" xml:space="preserve"><value>Display mode</value></data>
+  <data name="Tray_DesktopWidget" xml:space="preserve"><value>Desktop widget</value></data>
+  <data name="Tray_TaskbarLabel" xml:space="preserve"><value>Taskbar label</value></data>
+  <data name="Tray_CheckUpdates" xml:space="preserve"><value>Check for updates...</value></data>
+  <data name="Tray_Unavailable" xml:space="preserve"><value>Codex Usage · unavailable</value></data>
+  <data name="Tray_Remaining" xml:space="preserve"><value>Codex · {0}% remaining</value></data>
+  <data name="Taskbar_OpenWidget" xml:space="preserve"><value>Open widget</value></data>
+  <data name="Taskbar_PreviewActivity" xml:space="preserve"><value>Preview activity animation</value></data>
+  <data name="Taskbar_UseDesktopWidget" xml:space="preserve"><value>Use desktop widget</value></data>
+  <data name="Taskbar_UsageUnavailable" xml:space="preserve"><value>Codex usage is currently unavailable.</value></data>
+  <data name="Taskbar_Remaining" xml:space="preserve"><value>{0}: {1}% remaining</value></data>
+  <data name="Taskbar_RemainingWithReset" xml:space="preserve"><value>{0}: {1}% remaining · resets {2}</value></data>
+</root>

--- a/src/CodexUsageWidget/Resources/Strings.zh-CN.resx
+++ b/src/CodexUsageWidget/Resources/Strings.zh-CN.resx
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="App_Name" xml:space="preserve"><value>Codex 用量小组件</value></data>
+  <data name="App_MainTitle" xml:space="preserve"><value>Codex 用量</value></data>
+  <data name="App_InstallFailure" xml:space="preserve"><value>Codex 用量小组件无法为当前用户完成安装。{0}</value></data>
+  <data name="App_StartupFailure" xml:space="preserve"><value>Codex 用量小组件无法启动。请查看以下目录中的日志：{0}</value></data>
+  <data name="Common_Available" xml:space="preserve"><value>可用</value></data>
+  <data name="Common_Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Common_CheckAgain" xml:space="preserve"><value>重新检查</value></data>
+  <data name="Common_Close" xml:space="preserve"><value>关闭</value></data>
+  <data name="Common_Exit" xml:space="preserve"><value>退出</value></data>
+  <data name="Common_NoneAvailable" xml:space="preserve"><value>暂无可用额度</value></data>
+  <data name="Common_Refresh" xml:space="preserve"><value>刷新</value></data>
+  <data name="Common_Settings" xml:space="preserve"><value>设置</value></data>
+  <data name="Common_Unlimited" xml:space="preserve"><value>不限量</value></data>
+  <data name="Main_ActivityRunning" xml:space="preserve"><value>Codex 任务正在运行</value></data>
+  <data name="Main_RefreshUsage" xml:space="preserve"><value>刷新用量</value></data>
+  <data name="Main_ShowCompact" xml:space="preserve"><value>显示紧凑视图</value></data>
+  <data name="Main_ShowDetails" xml:space="preserve"><value>显示详情</value></data>
+  <data name="Main_ToggleLayout" xml:space="preserve"><value>切换小组件布局</value></data>
+  <data name="Main_UseTaskbarLabel" xml:space="preserve"><value>使用任务栏标签</value></data>
+  <data name="Main_StartupPreferenceError" xml:space="preserve"><value>无法更新开机启动设置。</value></data>
+  <data name="Main_UpdateOpenError" xml:space="preserve"><value>Windows 无法打开小组件的发布页面。</value></data>
+  <data name="Status_Connecting" xml:space="preserve"><value>正在连接…</value></data>
+  <data name="Status_WaitingForCodex" xml:space="preserve"><value>正在等待 Codex</value></data>
+  <data name="Status_LocalWaiting" xml:space="preserve"><value>仅限本机 · 等待同步</value></data>
+  <data name="Status_Offline" xml:space="preserve"><value>离线</value></data>
+  <data name="Status_LocalRetry" xml:space="preserve"><value>仅限本机 · 请选择刷新后重试</value></data>
+  <data name="Status_Syncing" xml:space="preserve"><value>正在同步…</value></data>
+  <data name="Status_LivePlan" xml:space="preserve"><value>实时 · {0}</value></data>
+  <data name="Status_HeadlineRemaining" xml:space="preserve"><value>剩余 {0}</value></data>
+  <data name="Status_LocalUpdated" xml:space="preserve"><value>仅限本机 · 更新于 {0}</value></data>
+  <data name="Status_NoLimits" xml:space="preserve"><value>未返回订阅用量限制。请先运行 codex login。</value></data>
+  <data name="Error_CliNotFound" xml:space="preserve"><value>在 PATH 中找不到 Codex CLI。</value></data>
+  <data name="Error_LoginRequired" xml:space="preserve"><value>请运行 codex login，然后刷新。</value></data>
+  <data name="Error_ResponseTimeout" xml:space="preserve"><value>Codex 响应超时。</value></data>
+  <data name="Error_Unexpected" xml:space="preserve"><value>无法读取 Codex 用量。{0}</value></data>
+  <data name="Warning_WorkspaceCreditsDepleted" xml:space="preserve"><value>工作区额度已用尽。</value></data>
+  <data name="Warning_WorkspaceUsageLimitReached" xml:space="preserve"><value>已达到工作区用量限制。</value></data>
+  <data name="Warning_UsageLimitReached" xml:space="preserve"><value>已达到 Codex 用量限制。</value></data>
+  <data name="Warning_SpendControlReached" xml:space="preserve"><value>已达到个人消费限制。</value></data>
+  <data name="Usage_FiveHourLimit" xml:space="preserve"><value>5 小时限制</value></data>
+  <data name="Usage_WeeklyLimit" xml:space="preserve"><value>每周限制</value></data>
+  <data name="Usage_DayLimit" xml:space="preserve"><value>{0} 天限制</value></data>
+  <data name="Usage_HourLimit" xml:space="preserve"><value>{0} 小时限制</value></data>
+  <data name="Usage_MinuteLimit" xml:space="preserve"><value>{0} 分钟限制</value></data>
+  <data name="Usage_PrimaryLimit" xml:space="preserve"><value>主要限制</value></data>
+  <data name="Usage_SecondaryLimit" xml:space="preserve"><value>次要限制</value></data>
+  <data name="Usage_UsedPercent" xml:space="preserve"><value>已用 {0}%</value></data>
+  <data name="Usage_RemainingPercent" xml:space="preserve"><value>剩余 {0}%</value></data>
+  <data name="Usage_ResetUnavailable" xml:space="preserve"><value>暂无重置时间</value></data>
+  <data name="Usage_ResetsNow" xml:space="preserve"><value>现在重置</value></data>
+  <data name="Usage_ResetsInHours" xml:space="preserve"><value>{0} 小时后重置 · {1}</value></data>
+  <data name="Usage_ResetsAt" xml:space="preserve"><value>{0} 重置</value></data>
+  <data name="Usage_CreditsRemaining" xml:space="preserve"><value>剩余 {0}</value></data>
+  <data name="Usage_ChatGptCredits" xml:space="preserve"><value>ChatGPT 额度</value></data>
+  <data name="Usage_IndividualSpendLimit" xml:space="preserve"><value>个人消费限制</value></data>
+  <data name="Usage_SpendLimitValue" xml:space="preserve"><value>已用 {0} / {1} · 剩余 {2}%</value></data>
+  <data name="Usage_SpendLimitResets" xml:space="preserve"><value>消费限制重置时间</value></data>
+  <data name="Usage_RateLimitResets" xml:space="preserve"><value>用量限制重置次数</value></data>
+  <data name="Usage_CountAvailable" xml:space="preserve"><value>可用 {0}</value></data>
+  <data name="Usage_SectionOverview" xml:space="preserve"><value>概览</value></data>
+  <data name="Usage_SectionCreditsLimits" xml:space="preserve"><value>额度与限制</value></data>
+  <data name="Usage_SectionTokenActivity" xml:space="preserve"><value>TOKEN 活动</value></data>
+  <data name="Usage_NotQuotaConsumption" xml:space="preserve"><value>不计入用量额度</value></data>
+  <data name="Usage_SectionModelLimits" xml:space="preserve"><value>模型专属限制</value></data>
+  <data name="Token_Lifetime" xml:space="preserve"><value>累计 Token</value></data>
+  <data name="Token_PeakDaily" xml:space="preserve"><value>单日 Token 峰值</value></data>
+  <data name="Token_LongestTurn" xml:space="preserve"><value>最长任务时长</value></data>
+  <data name="Token_CurrentStreak" xml:space="preserve"><value>当前连续天数</value></data>
+  <data name="Token_LongestStreak" xml:space="preserve"><value>最长连续天数</value></data>
+  <data name="Token_Days" xml:space="preserve"><value>{0} 天</value></data>
+  <data name="Token_Count" xml:space="preserve"><value>{0} Token</value></data>
+  <data name="Token_ChartPeak" xml:space="preserve"><value>图表峰值的 {0}%</value></data>
+  <data name="Token_DurationHoursMinutes" xml:space="preserve"><value>{0} 小时 {1} 分钟</value></data>
+  <data name="Token_DurationMinutes" xml:space="preserve"><value>{0} 分钟</value></data>
+  <data name="Settings_Description" xml:space="preserve"><value>选择 Codex 用量小组件的外观和行为。</value></data>
+  <data name="Settings_SectionGeneral" xml:space="preserve"><value>常规</value></data>
+  <data name="Settings_StartWithWindows" xml:space="preserve"><value>开机启动</value></data>
+  <data name="Settings_StartWithWindowsDescription" xml:space="preserve"><value>登录 Windows 时启动小组件</value></data>
+  <data name="Settings_Theme_Title" xml:space="preserve"><value>主题</value></data>
+  <data name="Settings_Theme_Description" xml:space="preserve"><value>跟随 Windows 主题，或固定使用一种主题。</value></data>
+  <data name="Settings_Theme_System" xml:space="preserve"><value>跟随 Windows</value></data>
+  <data name="Settings_Theme_SystemDescription" xml:space="preserve"><value>随 Windows 应用主题切换</value></data>
+  <data name="Settings_Theme_SystemAutomation" xml:space="preserve"><value>使用 Windows 主题</value></data>
+  <data name="Settings_Theme_Light" xml:space="preserve"><value>浅色</value></data>
+  <data name="Settings_Theme_LightDescription" xml:space="preserve"><value>浅色界面和深色文字</value></data>
+  <data name="Settings_Theme_LightAutomation" xml:space="preserve"><value>使用浅色主题</value></data>
+  <data name="Settings_Theme_Dark" xml:space="preserve"><value>深色</value></data>
+  <data name="Settings_Theme_DarkDescription" xml:space="preserve"><value>深色界面和浅色文字</value></data>
+  <data name="Settings_Theme_DarkAutomation" xml:space="preserve"><value>使用深色主题</value></data>
+  <data name="Settings_Accent_Title" xml:space="preserve"><value>强调色</value></data>
+  <data name="Settings_Accent_Blue" xml:space="preserve"><value>蓝色</value></data>
+  <data name="Settings_Accent_Violet" xml:space="preserve"><value>紫色</value></data>
+  <data name="Settings_Accent_Teal" xml:space="preserve"><value>青色</value></data>
+  <data name="Settings_Accent_Emerald" xml:space="preserve"><value>翠绿色</value></data>
+  <data name="Settings_Accent_Pink" xml:space="preserve"><value>粉色</value></data>
+  <data name="Settings_Accent_Automation" xml:space="preserve"><value>使用{0}强调色</value></data>
+  <data name="Settings_Accent_BlueAutomation" xml:space="preserve"><value>使用蓝色强调色</value></data>
+  <data name="Settings_Accent_VioletAutomation" xml:space="preserve"><value>使用紫色强调色</value></data>
+  <data name="Settings_Accent_TealAutomation" xml:space="preserve"><value>使用青色强调色</value></data>
+  <data name="Settings_Accent_EmeraldAutomation" xml:space="preserve"><value>使用翠绿色强调色</value></data>
+  <data name="Settings_Accent_PinkAutomation" xml:space="preserve"><value>使用粉色强调色</value></data>
+  <data name="Settings_Layout_Title" xml:space="preserve"><value>小组件布局</value></data>
+  <data name="Settings_Layout_Description" xml:space="preserve"><value>选择桌面小组件显示的信息量。</value></data>
+  <data name="Settings_Layout_Compact" xml:space="preserve"><value>紧凑</value></data>
+  <data name="Settings_Layout_CompactDescription" xml:space="preserve"><value>快速查看用量摘要</value></data>
+  <data name="Settings_Layout_CompactAutomation" xml:space="preserve"><value>使用紧凑布局</value></data>
+  <data name="Settings_Layout_Detailed" xml:space="preserve"><value>详情</value></data>
+  <data name="Settings_Layout_DetailedDescription" xml:space="preserve"><value>显示完整用量明细</value></data>
+  <data name="Settings_Layout_DetailedAutomation" xml:space="preserve"><value>使用详情布局</value></data>
+  <data name="Settings_SectionUsage" xml:space="preserve"><value>用量</value></data>
+  <data name="Settings_DisplayedLimit_Title" xml:space="preserve"><value>显示的限制</value></data>
+  <data name="Settings_DisplayedLimit_Description" xml:space="preserve"><value>选择小组件、任务栏标签和托盘图标显示的限制。</value></data>
+  <data name="Settings_DisplayedLimit_FiveHourDescription" xml:space="preserve"><value>显示全局五小时用量窗口</value></data>
+  <data name="Settings_DisplayedLimit_FiveHourAutomation" xml:space="preserve"><value>显示 5 小时限制</value></data>
+  <data name="Settings_DisplayedLimit_FiveHourUnavailable" xml:space="preserve"><value>Codex 未返回此账户的全局 5 小时限制。</value></data>
+  <data name="Settings_DisplayedLimit_WeeklyDescription" xml:space="preserve"><value>显示全局每周用量窗口</value></data>
+  <data name="Settings_DisplayedLimit_WeeklyAutomation" xml:space="preserve"><value>显示每周限制</value></data>
+  <data name="Settings_DisplayedLimit_MostConstrained" xml:space="preserve"><value>剩余额度最少</value></data>
+  <data name="Settings_DisplayedLimit_MostConstrainedDescription" xml:space="preserve"><value>显示当前剩余比例最低的可用限制</value></data>
+  <data name="Settings_DisplayedLimit_MostConstrainedAutomation" xml:space="preserve"><value>显示剩余额度最少的限制</value></data>
+  <data name="Settings_SectionFeatures" xml:space="preserve"><value>功能</value></data>
+  <data name="Settings_Language_Title" xml:space="preserve"><value>语言</value></data>
+  <data name="Settings_Language_Description" xml:space="preserve"><value>跟随 Windows 显示语言，或固定使用一种语言。</value></data>
+  <data name="Settings_Language_System" xml:space="preserve"><value>跟随 Windows</value></data>
+  <data name="Settings_Language_SystemDescription" xml:space="preserve"><value>支持简体中文时使用中文，否则使用英语</value></data>
+  <data name="Settings_Language_SystemAutomation" xml:space="preserve"><value>跟随 Windows 显示语言</value></data>
+  <data name="Settings_Language_English" xml:space="preserve"><value>English</value></data>
+  <data name="Settings_Language_EnglishDescription" xml:space="preserve"><value>始终使用英语</value></data>
+  <data name="Settings_Language_EnglishAutomation" xml:space="preserve"><value>使用英语</value></data>
+  <data name="Settings_Language_Chinese" xml:space="preserve"><value>简体中文</value></data>
+  <data name="Settings_Language_ChineseDescription" xml:space="preserve"><value>始终使用简体中文</value></data>
+  <data name="Settings_Language_ChineseAutomation" xml:space="preserve"><value>使用简体中文</value></data>
+  <data name="Activity_Title" xml:space="preserve"><value>Codex 运行状态</value></data>
+  <data name="Activity_Description" xml:space="preserve"><value>Codex 本地任务运行时显示状态点</value></data>
+  <data name="Activity_Privacy" xml:space="preserve"><value>隐私说明：只有活动类型、会话 ID 和任务 ID 会通过仅限当前用户的本地管道传输。提示词和回复始终留在 Codex 中。</value></data>
+  <data name="Activity_RemoveHooks" xml:space="preserve"><value>移除钩子</value></data>
+  <data name="Activity_CopyHooksTooltip" xml:space="preserve"><value>复制 /hooks 并打开 Codex</value></data>
+  <data name="Activity_Checking" xml:space="preserve"><value>正在检查 Codex…</value></data>
+  <data name="Activity_CheckingDescription" xml:space="preserve"><value>正在读取本地钩子配置和 Codex 信任状态。</value></data>
+  <data name="Activity_OpenInCodex" xml:space="preserve"><value>在 Codex 中打开</value></data>
+  <data name="Activity_ReviewHooks" xml:space="preserve"><value>检查钩子</value></data>
+  <data name="Activity_SetupRequired" xml:space="preserve"><value>需要设置</value></data>
+  <data name="Activity_SetupRequiredDescription" xml:space="preserve"><value>安装三个本地生命周期钩子，以便 Codex 工作时显示任务栏状态点。写入前可以检查 hooks.json 的确切改动。</value></data>
+  <data name="Activity_UpdateAvailable" xml:space="preserve"><value>有可用更新</value></data>
+  <data name="Activity_UpdateDescription" xml:space="preserve"><value>已安装旧版小组件的活动处理程序。检查确切改动后，可将其更新为更快且不依赖路径的桥接程序。</value></data>
+  <data name="Activity_ReviewUpdate" xml:space="preserve"><value>检查更新</value></data>
+  <data name="Activity_OneStepLeft" xml:space="preserve"><value>还差一步</value></data>
+  <data name="Activity_ApprovalDescription" xml:space="preserve"><value>钩子已安装。需要在 Codex 中批准一次确切定义，钩子才能运行。</value></data>
+  <data name="Activity_ApproveInCodex" xml:space="preserve"><value>在 Codex 中批准</value></data>
+  <data name="Activity_Ready" xml:space="preserve"><value>运行状态点已就绪</value></data>
+  <data name="Activity_ReadyDescription" xml:space="preserve"><value>三个钩子均已安装并受信任。</value></data>
+  <data name="Activity_ReviewRequired" xml:space="preserve"><value>需要检查</value></data>
+  <data name="Activity_ModifiedDescription" xml:space="preserve"><value>Codex 已暂停改动过的定义。请重新检查，活动报告随后会恢复。</value></data>
+  <data name="Activity_ReviewInCodex" xml:space="preserve"><value>在 Codex 中检查</value></data>
+  <data name="Activity_HooksDisabled" xml:space="preserve"><value>Codex 中的钩子已禁用</value></data>
+  <data name="Activity_HooksDisabledDescription" xml:space="preserve"><value>安装前，请在 Codex 配置的 [features] 部分设置 hooks = true。</value></data>
+  <data name="Activity_StatusUnavailable" xml:space="preserve"><value>已安装 · 状态不可用</value></data>
+  <data name="Activity_StatusUnavailableDescription" xml:space="preserve"><value>钩子已安装，但无法验证其信任状态。</value></data>
+  <data name="Activity_StatusUnavailableWithDetail" xml:space="preserve"><value>钩子已安装，但 Codex 无法返回其信任状态。{0}</value></data>
+  <data name="Activity_OpenHooksInCodex" xml:space="preserve"><value>在 Codex 中打开钩子</value></data>
+  <data name="Activity_SetupUnavailable" xml:space="preserve"><value>设置不可用</value></data>
+  <data name="Activity_SetupUnavailableDescription" xml:space="preserve"><value>无法读取活动钩子配置。</value></data>
+  <data name="Activity_SetupErrorDetail" xml:space="preserve"><value>无法完成活动钩子设置。{0}</value></data>
+  <data name="Activity_StatusTimeout" xml:space="preserve"><value>Codex 未及时返回钩子状态。请检查 CLI 是否可用，然后重试。</value></data>
+  <data name="Activity_CodexOpenCopied" xml:space="preserve"><value>Codex 已打开。请粘贴 /hooks 并批准三个定义。返回此处时会刷新状态。</value></data>
+  <data name="Activity_CodexOpenType" xml:space="preserve"><value>Codex 已打开。请输入 /hooks 并批准三个定义。返回此处时会刷新状态。</value></data>
+  <data name="Activity_ReviewTitle" xml:space="preserve"><value>检查 Codex 活动钩子</value></data>
+  <data name="Activity_ReviewInstallHeading" xml:space="preserve"><value>检查活动钩子安装</value></data>
+  <data name="Activity_ReviewRemoveHeading" xml:space="preserve"><value>检查活动钩子移除</value></data>
+  <data name="Activity_ReviewInstallDescription" xml:space="preserve"><value>小组件将写入以下确切的 ~/.codex/hooks.json 内容。现有钩子和未知字段会保留。</value></data>
+  <data name="Activity_ReviewRemoveDescription" xml:space="preserve"><value>只会移除与此小组件可执行文件完全匹配的处理程序。其他钩子定义会保留。</value></data>
+  <data name="Activity_InstallHooks" xml:space="preserve"><value>安装钩子</value></data>
+  <data name="Tray_Open" xml:space="preserve"><value>打开</value></data>
+  <data name="Tray_Settings" xml:space="preserve"><value>设置...</value></data>
+  <data name="Tray_DisplayMode" xml:space="preserve"><value>显示模式</value></data>
+  <data name="Tray_DesktopWidget" xml:space="preserve"><value>桌面小组件</value></data>
+  <data name="Tray_TaskbarLabel" xml:space="preserve"><value>任务栏标签</value></data>
+  <data name="Tray_CheckUpdates" xml:space="preserve"><value>检查更新...</value></data>
+  <data name="Tray_Unavailable" xml:space="preserve"><value>Codex 用量 · 暂不可用</value></data>
+  <data name="Tray_Remaining" xml:space="preserve"><value>Codex · 剩余 {0}%</value></data>
+  <data name="Taskbar_OpenWidget" xml:space="preserve"><value>打开小组件</value></data>
+  <data name="Taskbar_PreviewActivity" xml:space="preserve"><value>预览活动动画</value></data>
+  <data name="Taskbar_UseDesktopWidget" xml:space="preserve"><value>使用桌面小组件</value></data>
+  <data name="Taskbar_UsageUnavailable" xml:space="preserve"><value>Codex 用量当前不可用。</value></data>
+  <data name="Taskbar_Remaining" xml:space="preserve"><value>{0}：剩余 {1}%</value></data>
+  <data name="Taskbar_RemainingWithReset" xml:space="preserve"><value>{0}：剩余 {1}% · {2} 重置</value></data>
+</root>

--- a/src/CodexUsageWidget/Resources/Strings.zh-CN.resx
+++ b/src/CodexUsageWidget/Resources/Strings.zh-CN.resx
@@ -126,9 +126,9 @@
   <data name="Settings_DisplayedLimit_MostConstrainedAutomation" xml:space="preserve"><value>显示剩余额度最少的限制</value></data>
   <data name="Settings_SectionFeatures" xml:space="preserve"><value>功能</value></data>
   <data name="Settings_Language_Title" xml:space="preserve"><value>语言</value></data>
-  <data name="Settings_Language_Description" xml:space="preserve"><value>跟随 Windows 显示语言，或固定使用一种语言。</value></data>
+  <data name="Settings_Language_Description" xml:space="preserve"><value>选择英语或简体中文，也可让 Windows 自动选择。</value></data>
   <data name="Settings_Language_System" xml:space="preserve"><value>跟随 Windows</value></data>
-  <data name="Settings_Language_SystemDescription" xml:space="preserve"><value>支持简体中文时使用中文，否则使用英语</value></data>
+  <data name="Settings_Language_SystemDescription" xml:space="preserve"><value>Windows 为简体中文时使用简体中文，否则使用英语。</value></data>
   <data name="Settings_Language_SystemAutomation" xml:space="preserve"><value>跟随 Windows 显示语言</value></data>
   <data name="Settings_Language_English" xml:space="preserve"><value>English</value></data>
   <data name="Settings_Language_EnglishDescription" xml:space="preserve"><value>始终使用英语</value></data>
@@ -176,6 +176,14 @@
   <data name="Activity_ReviewInstallDescription" xml:space="preserve"><value>小组件将写入以下确切的 ~/.codex/hooks.json 内容。现有钩子和未知字段会保留。</value></data>
   <data name="Activity_ReviewRemoveDescription" xml:space="preserve"><value>只会移除与此小组件可执行文件完全匹配的处理程序。其他钩子定义会保留。</value></data>
   <data name="Activity_InstallHooks" xml:space="preserve"><value>安装钩子</value></data>
+  <data name="Activity_CommandAlreadyInstalled" xml:space="preserve"><value>活动钩子已安装。</value></data>
+  <data name="Activity_CommandNoMatching" xml:space="preserve"><value>未找到已安装的匹配活动钩子。</value></data>
+  <data name="Activity_CommandProposed" xml:space="preserve"><value>拟写入的 ~/.codex/hooks.json：</value></data>
+  <data name="Activity_CommandApplyPrompt" xml:space="preserve"><value>应用此更改？[y/N] </value></data>
+  <data name="Activity_CommandNoChanges" xml:space="preserve"><value>未进行任何更改。</value></data>
+  <data name="Activity_CommandInstalled" xml:space="preserve"><value>活动钩子已安装。请使用 /hooks 检查并信任确切定义。</value></data>
+  <data name="Activity_CommandRemoved" xml:space="preserve"><value>已移除匹配的活动钩子。</value></data>
+  <data name="Activity_CommandFailure" xml:space="preserve"><value>活动钩子配置失败：{0}</value></data>
   <data name="Tray_Open" xml:space="preserve"><value>打开</value></data>
   <data name="Tray_Settings" xml:space="preserve"><value>设置...</value></data>
   <data name="Tray_DisplayMode" xml:space="preserve"><value>显示模式</value></data>

--- a/src/CodexUsageWidget/Views/ActivityHookChangeReviewWindow.xaml
+++ b/src/CodexUsageWidget/Views/ActivityHookChangeReviewWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:CodexUsageWidget.Views.Controls"
-        Title="Review Codex activity hooks"
+        xmlns:localization="clr-namespace:CodexUsageWidget.Views.Localization"
+        Title="{localization:Loc Activity_ReviewTitle}"
         Width="620"
         Height="520"
         ResizeMode="NoResize"
@@ -32,7 +33,7 @@
                         Height="28"
                         Margin="12,-4,-4,0"
                         VerticalAlignment="Top"
-                        ToolTip="Close"
+                        ToolTip="{localization:Loc Common_Close}"
                         IsCancel="True"
                         Style="{StaticResource IconButton}">
                     <Path Width="10"
@@ -64,7 +65,7 @@
                         Margin="0,16,0,0"
                         Orientation="Horizontal"
                         HorizontalAlignment="Right">
-                <Button Content="Cancel"
+                <Button Content="{localization:Loc Common_Cancel}"
                         Margin="0,0,8,0"
                         IsCancel="True"
                         Style="{StaticResource DialogButton}" />

--- a/src/CodexUsageWidget/Views/ActivityHookChangeReviewWindow.xaml.cs
+++ b/src/CodexUsageWidget/Views/ActivityHookChangeReviewWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Windows;
 using System.Windows.Input;
 using CodexUsageWidget.Application;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Views;
 
@@ -13,13 +14,15 @@ public partial class ActivityHookChangeReviewWindow : Window
 
         var installing = preview.Kind == ActivityHookChangeKind.Install;
         HeadingText.Text = installing
-            ? "Review activity hook installation"
-            : "Review activity hook removal";
+            ? Strings.Get("Activity_ReviewInstallHeading")
+            : Strings.Get("Activity_ReviewRemoveHeading");
         DescriptionText.Text = installing
-            ? "The widget will write this exact ~/.codex/hooks.json content. Existing hooks and unknown fields are preserved."
-            : "Only handlers that exactly match this widget executable will be removed. Other hook definitions are preserved.";
+            ? Strings.Get("Activity_ReviewInstallDescription")
+            : Strings.Get("Activity_ReviewRemoveDescription");
         ProposedContentText.Text = preview.ProposedContent;
-        ApplyButton.Content = installing ? "Install hooks" : "Remove hooks";
+        ApplyButton.Content = installing
+            ? Strings.Get("Activity_InstallHooks")
+            : Strings.Get("Activity_RemoveHooks");
         if (!installing)
         {
             ApplyButton.Style = (Style)FindResource("DangerDialogButton");

--- a/src/CodexUsageWidget/Views/Controls/ActivityHookSetupControl.xaml
+++ b/src/CodexUsageWidget/Views/Controls/ActivityHookSetupControl.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="CodexUsageWidget.Views.Controls.ActivityHookSetupControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:CodexUsageWidget.Views.Controls">
+             xmlns:controls="clr-namespace:CodexUsageWidget.Views.Controls"
+             xmlns:localization="clr-namespace:CodexUsageWidget.Views.Localization">
     <StackPanel>
         <Grid>
             <Grid.ColumnDefinitions>
@@ -17,11 +18,11 @@
                          Fill="{DynamicResource TextPrimary}" />
             </Canvas>
             <StackPanel Grid.Column="1">
-                <TextBlock Text="Codex activity"
+                <TextBlock Text="{localization:Loc Activity_Title}"
                            FontSize="15"
                            FontWeight="SemiBold"
                            Foreground="{DynamicResource TextPrimary}" />
-                <TextBlock Text="Show when a local Codex turn is running"
+                <TextBlock Text="{localization:Loc Activity_Description}"
                            Margin="0,3,0,0"
                            Style="{StaticResource SupportingText}" />
             </StackPanel>
@@ -53,7 +54,7 @@
                 BorderBrush="{DynamicResource DividerBrush}"
                 BorderThickness="1"
                 CornerRadius="8">
-            <TextBlock Text="Privacy: only activity type, session ID, and turn ID travel through a local user-only pipe. Prompts and responses never leave Codex."
+            <TextBlock Text="{localization:Loc Activity_Privacy}"
                        TextWrapping="Wrap"
                        LineHeight="16"
                        FontSize="10.5"
@@ -73,11 +74,11 @@
             </Grid.ColumnDefinitions>
             <StackPanel Orientation="Horizontal"
                         HorizontalAlignment="Left">
-                <Button Content="Check again"
+                <Button Content="{localization:Loc Common_CheckAgain}"
                         IsEnabled="{Binding CanRefresh}"
                         Click="RefreshButton_OnClick"
                         Style="{StaticResource DialogButton}" />
-                <Button Content="Remove hooks"
+                <Button Content="{localization:Loc Activity_RemoveHooks}"
                         Margin="8,0,0,0"
                         Visibility="{Binding CanUninstall, Converter={StaticResource BooleanToVisibilityConverter}}"
                         Click="UninstallButton_OnClick"
@@ -92,7 +93,7 @@
                                        Click="InstallButton_OnClick"
                                        Style="{StaticResource PrimaryDialogButton}" />
                 <controls:AccentButton Content="{Binding CodexActionLabel}"
-                                       ToolTip="Copies /hooks and opens Codex"
+                                       ToolTip="{localization:Loc Activity_CopyHooksTooltip}"
                                        Visibility="{Binding CanOpenCodex, Converter={StaticResource BooleanToVisibilityConverter}}"
                                        Click="OpenCodexButton_OnClick"
                                        Style="{StaticResource PrimaryDialogButton}" />

--- a/src/CodexUsageWidget/Views/Controls/ActivityHookSetupControl.xaml.cs
+++ b/src/CodexUsageWidget/Views/Controls/ActivityHookSetupControl.xaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
 using CodexUsageWidget.Application;
+using CodexUsageWidget.Localization;
 using CodexUsageWidget.Views.ViewModels;
 
 namespace CodexUsageWidget.Views.Controls;
@@ -18,9 +19,14 @@ public partial class ActivityHookSetupControl : System.Windows.Controls.UserCont
     private readonly ICodexLauncher _codexLauncher;
     private readonly CancellationTokenSource _lifetime = new();
     private Window? _hostWindow;
+    private ActivityHookSetupStatus? _lastStatus;
+    private string? _errorMessage;
+    private string? _errorResourceKey;
+    private bool? _instructionCommandCopied;
     private bool _refreshInProgress;
     private bool _refreshTrustOnActivation;
-    private bool _disposed;
+    private bool _stringsSubscribed;
+    private volatile bool _disposed;
 
     public ActivityHookSetupControl(
         IActivityHookSetupService setupService,
@@ -38,29 +44,54 @@ public partial class ActivityHookSetupControl : System.Windows.Controls.UserCont
 
     private async void ActivityHookSetupControlOnLoaded(object sender, RoutedEventArgs e)
     {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (!_stringsSubscribed)
+        {
+            Strings.Current.PropertyChanged += StringsOnPropertyChanged;
+            _stringsSubscribed = true;
+        }
+
         _hostWindow = Window.GetWindow(this);
         if (_hostWindow is not null)
         {
             _hostWindow.Activated += HostWindowOnActivated;
+            _hostWindow.Closed += HostWindowOnClosed;
         }
 
         await RefreshStatusAsync();
     }
 
-    private void ActivityHookSetupControlOnUnloaded(object sender, RoutedEventArgs e)
-    {
-        if (_hostWindow is not null)
-        {
-            _hostWindow.Activated -= HostWindowOnActivated;
-            _hostWindow = null;
-        }
+    private void ActivityHookSetupControlOnUnloaded(object sender, RoutedEventArgs e) =>
+        DisposeControl();
 
+    private void HostWindowOnClosed(object? sender, EventArgs e) =>
+        DisposeControl();
+
+    private void DisposeControl()
+    {
         if (_disposed)
         {
             return;
         }
 
         _disposed = true;
+        if (_hostWindow is not null)
+        {
+            _hostWindow.Activated -= HostWindowOnActivated;
+            _hostWindow.Closed -= HostWindowOnClosed;
+            _hostWindow = null;
+        }
+
+        if (_stringsSubscribed)
+        {
+            Strings.Current.PropertyChanged -= StringsOnPropertyChanged;
+            _stringsSubscribed = false;
+        }
+
         _lifetime.Cancel();
         _lifetime.Dispose();
     }
@@ -82,6 +113,10 @@ public partial class ActivityHookSetupControl : System.Windows.Controls.UserCont
         }
 
         _refreshInProgress = true;
+        _lastStatus = null;
+        _errorMessage = null;
+        _errorResourceKey = null;
+        _instructionCommandCopied = null;
         DataContext = ActivityHookSetupViewModel.Loading();
         InstructionText.Text = string.Empty;
         InstructionText.Visibility = Visibility.Collapsed;
@@ -90,6 +125,7 @@ public partial class ActivityHookSetupControl : System.Windows.Controls.UserCont
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token);
             timeout.CancelAfter(StatusTimeout);
             var status = await _setupService.GetStatusAsync(timeout.Token);
+            _lastStatus = status;
             var viewModel = ActivityHookSetupViewModel.FromStatus(status);
             DataContext = viewModel;
             if (_refreshTrustOnActivation && !viewModel.CanOpenCodex)
@@ -102,12 +138,11 @@ public partial class ActivityHookSetupControl : System.Windows.Controls.UserCont
         }
         catch (OperationCanceledException)
         {
-            DataContext = ActivityHookSetupViewModel.Error(
-                "Codex did not report hook status in time. Check that the CLI is available, then try again.");
+            SetError(resourceKey: "Activity_StatusTimeout");
         }
         catch (Exception ex) when (ex is IOException or InvalidOperationException or UnauthorizedAccessException)
         {
-            DataContext = ActivityHookSetupViewModel.Error(ex.Message);
+            SetError(message: ex.Message);
         }
         finally
         {
@@ -149,7 +184,7 @@ public partial class ActivityHookSetupControl : System.Windows.Controls.UserCont
         }
         catch (Exception ex) when (ex is IOException or InvalidOperationException or UnauthorizedAccessException)
         {
-            DataContext = ActivityHookSetupViewModel.Error(ex.Message);
+            SetError(message: ex.Message);
         }
     }
 
@@ -160,16 +195,64 @@ public partial class ActivityHookSetupControl : System.Windows.Controls.UserCont
         try
         {
             _codexLauncher.OpenInteractive();
-            InstructionText.Text = commandCopied
-                ? "Codex is open. Paste /hooks and approve the three definitions. Status refreshes when you return here."
-                : "Codex is open. Type /hooks and approve the three definitions. Status refreshes when you return here.";
-            InstructionText.Visibility = Visibility.Visible;
+            _instructionCommandCopied = commandCopied;
+            SetInstructionText(commandCopied);
         }
         catch (Exception ex) when (ex is Win32Exception or FileNotFoundException or InvalidOperationException)
         {
             _refreshTrustOnActivation = false;
-            DataContext = ActivityHookSetupViewModel.Error(ex.Message);
+            SetError(message: ex.Message);
         }
+    }
+
+    private void StringsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != "Item[]" || _disposed)
+        {
+            return;
+        }
+
+        if (!Dispatcher.CheckAccess())
+        {
+            if (!Dispatcher.HasShutdownStarted && !Dispatcher.HasShutdownFinished)
+            {
+                _ = Dispatcher.BeginInvoke(
+                    () => StringsOnPropertyChanged(sender, e));
+            }
+
+            return;
+        }
+
+        DataContext = _lastStatus is not null
+            ? ActivityHookSetupViewModel.FromStatus(_lastStatus)
+            : _errorResourceKey is not null
+                ? ActivityHookSetupViewModel.Error(Strings.Get(_errorResourceKey))
+                : _errorMessage is not null
+                    ? ActivityHookSetupViewModel.Error(
+                        Strings.Format("Activity_SetupErrorDetail", _errorMessage))
+                    : ActivityHookSetupViewModel.Loading();
+        if (_instructionCommandCopied is { } commandCopied)
+        {
+            SetInstructionText(commandCopied);
+        }
+    }
+
+    private void SetError(string? message = null, string? resourceKey = null)
+    {
+        _lastStatus = null;
+        _errorMessage = message;
+        _errorResourceKey = resourceKey;
+        DataContext = ActivityHookSetupViewModel.Error(
+            resourceKey is null
+                ? Strings.Format("Activity_SetupErrorDetail", message!)
+                : Strings.Get(resourceKey));
+    }
+
+    private void SetInstructionText(bool commandCopied)
+    {
+        InstructionText.Text = Strings.Get(
+            commandCopied ? "Activity_CodexOpenCopied" : "Activity_CodexOpenType");
+        InstructionText.Visibility = Visibility.Visible;
     }
 
     private static bool TryCopyHooksCommand()

--- a/src/CodexUsageWidget/Views/Controls/DetailedUsageView.xaml
+++ b/src/CodexUsageWidget/Views/Controls/DetailedUsageView.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="CodexUsageWidget.Views.Controls.DetailedUsageView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:CodexUsageWidget.Views.Controls">
+             xmlns:controls="clr-namespace:CodexUsageWidget.Views.Controls"
+             xmlns:localization="clr-namespace:CodexUsageWidget.Views.Localization">
     <ScrollViewer x:Name="DetailsScrollViewer"
                   Margin="16,4,10,8"
                   Padding="0,0,4,0"
@@ -16,7 +17,7 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="OVERVIEW" Style="{StaticResource SectionTitle}" />
+                        <TextBlock Text="{localization:Loc Usage_SectionOverview}" Style="{StaticResource SectionTitle}" />
                         <TextBlock Grid.Column="1"
                                    Text="{Binding HeadlineRemainingText}"
                                    FontFamily="{StaticResource UiFont}"
@@ -46,7 +47,7 @@
             <Border Visibility="{Binding HasAccountMetrics, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource SectionCard}">
                 <StackPanel>
-                    <TextBlock Text="CREDITS &amp; LIMITS"
+                    <TextBlock Text="{localization:Loc Usage_SectionCreditsLimits}"
                                Margin="0,0,0,9"
                                Style="{StaticResource SectionTitle}" />
                     <ItemsControl ItemsSource="{Binding AccountMetrics}">
@@ -82,9 +83,9 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="TOKEN ACTIVITY" Style="{StaticResource SectionTitle}" />
+                        <TextBlock Text="{localization:Loc Usage_SectionTokenActivity}" Style="{StaticResource SectionTitle}" />
                         <TextBlock Grid.Column="1"
-                                   Text="Not quota consumption"
+                                   Text="{localization:Loc Usage_NotQuotaConsumption}"
                                    Style="{StaticResource SupportingText}"
                                    FontSize="10.5"
                                    Foreground="{DynamicResource TextTertiary}" />
@@ -169,7 +170,7 @@
             <Border Visibility="{Binding HasModelLimits, Converter={StaticResource BooleanToVisibilityConverter}}"
                     Style="{StaticResource SectionCard}">
                 <StackPanel>
-                    <TextBlock Text="MODEL-SPECIFIC LIMITS"
+                    <TextBlock Text="{localization:Loc Usage_SectionModelLimits}"
                                Margin="0,0,0,8"
                                Style="{StaticResource SectionTitle}" />
                     <ItemsControl ItemsSource="{Binding ModelLimits}">

--- a/src/CodexUsageWidget/Views/Localization/LocExtension.cs
+++ b/src/CodexUsageWidget/Views/Localization/LocExtension.cs
@@ -1,0 +1,17 @@
+using System.Windows.Markup;
+using CodexUsageWidget.Localization;
+
+namespace CodexUsageWidget.Views.Localization;
+
+[MarkupExtensionReturnType(typeof(object))]
+public sealed class LocExtension(string key) : MarkupExtension
+{
+    public string Key { get; } = key;
+
+    public override object ProvideValue(IServiceProvider serviceProvider) =>
+        new System.Windows.Data.Binding($"[{Key}]")
+        {
+            Mode = System.Windows.Data.BindingMode.OneWay,
+            Source = Strings.Current
+        }.ProvideValue(serviceProvider);
+}

--- a/src/CodexUsageWidget/Views/MainWindow.xaml
+++ b/src/CodexUsageWidget/Views/MainWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:CodexUsageWidget.Views.Controls"
-        Title="Codex Usage"
+        xmlns:localization="clr-namespace:CodexUsageWidget.Views.Localization"
+        Title="{localization:Loc App_MainTitle}"
         Width="390"
         Height="290"
         MinWidth="390"
@@ -53,8 +54,8 @@
                         <controls:ActivityDotsIndicator x:Name="WidgetActivityDots"
                                                         Margin="18,0,0,0"
                                                         VerticalAlignment="Center"
-                                                        ToolTip="Codex task is running"
-                                                        AutomationProperties.Name="Codex task is running"
+                                                        ToolTip="{localization:Loc Main_ActivityRunning}"
+                                                        AutomationProperties.Name="{localization:Loc Main_ActivityRunning}"
                                                         DotBrush="{DynamicResource AccentDataBrush}" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,1,0,0">
@@ -70,7 +71,7 @@
                 <StackPanel Grid.Column="1"
                             Orientation="Horizontal"
                             VerticalAlignment="Center">
-                    <Button ToolTip="Refresh usage"
+                    <Button ToolTip="{localization:Loc Main_RefreshUsage}"
                             Style="{StaticResource IconButton}"
                             Click="RefreshButton_OnClick">
                         <Viewbox Width="16" Height="16">
@@ -85,8 +86,8 @@
                         </Viewbox>
                     </Button>
                     <Button x:Name="DensityButton"
-                            ToolTip="Show details"
-                            AutomationProperties.Name="Toggle widget layout"
+                            ToolTip="{localization:Loc Main_ShowDetails}"
+                            AutomationProperties.Name="{localization:Loc Main_ToggleLayout}"
                             Style="{StaticResource IconButton}"
                             Click="DensityButton_OnClick">
                         <Viewbox Width="16" Height="16">
@@ -106,7 +107,7 @@
                             </Canvas>
                         </Viewbox>
                     </Button>
-                    <Button ToolTip="Use taskbar label"
+                    <Button ToolTip="{localization:Loc Main_UseTaskbarLabel}"
                             Style="{StaticResource IconButton}"
                             Click="HideButton_OnClick">
                         <Viewbox Width="16" Height="16">
@@ -119,7 +120,7 @@
                             </Canvas>
                         </Viewbox>
                     </Button>
-                    <Button ToolTip="Exit"
+                    <Button ToolTip="{localization:Loc Common_Exit}"
                             Style="{StaticResource IconButton}"
                             Click="CloseButton_OnClick">
                         <Viewbox Width="16" Height="16">
@@ -154,8 +155,8 @@
                                 VerticalAlignment="Center"
                                 Orientation="Horizontal">
                         <Button x:Name="SettingsButton"
-                                ToolTip="Settings"
-                                AutomationProperties.Name="Settings"
+                                ToolTip="{localization:Loc Common_Settings}"
+                                AutomationProperties.Name="{localization:Loc Common_Settings}"
                                 Style="{StaticResource IconButton}"
                                 Click="SettingsButton_OnClick">
                             <Viewbox Width="16" Height="16">

--- a/src/CodexUsageWidget/Views/MainWindow.xaml.cs
+++ b/src/CodexUsageWidget/Views/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using CodexUsageWidget.Application;
 using CodexUsageWidget.Domain;
 using CodexUsageWidget.Infrastructure.Settings;
 using CodexUsageWidget.Infrastructure.Windows;
+using CodexUsageWidget.Localization;
 using CodexUsageWidget.Views.ViewModels;
 
 namespace CodexUsageWidget.Views;
@@ -28,6 +29,7 @@ public partial class MainWindow : Window
     private readonly StartupRegistrationService _startupRegistration;
     private readonly TrayIconService _trayIcon;
     private readonly AppThemeController _themeController;
+    private readonly AppLanguageController _languageController;
     private readonly TaskbarLabelWindow _taskbarLabel = new();
     private readonly WidgetVisibilityController _widgetVisibility;
     private readonly MainWindowCloseState _closeState = new();
@@ -52,7 +54,8 @@ public partial class MainWindow : Window
         DisplayedLimitPreferenceStore displayedLimitPreferenceStore,
         StartupRegistrationService startupRegistration,
         TrayIconService trayIcon,
-        AppThemeController themeController)
+        AppThemeController themeController,
+        AppLanguageController languageController)
     {
         _usageMonitor = usageMonitor;
         _activityMonitor = activityMonitor;
@@ -64,6 +67,7 @@ public partial class MainWindow : Window
         _startupRegistration = startupRegistration;
         _trayIcon = trayIcon;
         _themeController = themeController;
+        _languageController = languageController;
         _displayMode = displayModeStore.Load();
         _density = densityStore.Load();
         _displayedLimitPreference = displayedLimitPreferenceStore.Load();
@@ -252,8 +256,8 @@ public partial class MainWindow : Window
             : Visibility.Collapsed;
         DensityGlyphRotation.Angle = _density == WidgetDensity.Detailed ? 180d : 0d;
         DensityButton.ToolTip = _density == WidgetDensity.Detailed
-            ? "Show compact view"
-            : "Show details";
+            ? Strings.Get("Main_ShowCompact")
+            : Strings.Get("Main_ShowDetails");
 
         if (_density == WidgetDensity.Detailed)
         {
@@ -337,7 +341,8 @@ public partial class MainWindow : Window
                 _startupRegistration.IsEnabled,
                 _activityHookSetupService,
                 _codexLauncher,
-                _themeController.AccentPalette)
+                _themeController.AccentPalette,
+                _languageController.Preference)
             {
                 Owner = this
             };
@@ -347,6 +352,7 @@ public partial class MainWindow : Window
             window.WidgetDensityChanged += SetDensity;
             window.DisplayedLimitPreferenceChanged += SetDisplayedLimitPreference;
             window.StartWithWindowsChanged += SetStartupRegistration;
+            window.LanguagePreferenceChanged += SetLanguagePreference;
             window.ShowDialog();
         }
         finally
@@ -395,8 +401,8 @@ public partial class MainWindow : Window
 
         SetStartupRegistrationState(_startupRegistration.IsEnabled);
         System.Windows.MessageBox.Show(
-            "The Windows startup preference could not be updated.",
-            "Codex Usage Widget",
+            Strings.Get("Main_StartupPreferenceError"),
+            Strings.Get("App_Name"),
             MessageBoxButton.OK,
             MessageBoxImage.Warning);
     }
@@ -414,10 +420,24 @@ public partial class MainWindow : Window
         }
 
         System.Windows.MessageBox.Show(
-            "Windows could not open the widget release page.",
-            "Codex Usage Widget",
+            Strings.Get("Main_UpdateOpenError"),
+            Strings.Get("App_Name"),
             MessageBoxButton.OK,
             MessageBoxImage.Warning);
+    }
+
+    private void SetLanguagePreference(LanguagePreference preference)
+    {
+        _languageController.SetPreference(preference);
+        ApplyDensity(repositionBottomEdge: false);
+        if (_latestSnapshot is { } snapshot)
+        {
+            RenderSnapshot(snapshot);
+            return;
+        }
+
+        SetViewModel(UsageWidgetViewModel.Loading());
+        _ = _usageMonitor.RefreshAsync();
     }
 
     private void Widget_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/src/CodexUsageWidget/Views/SettingsWindow.xaml
+++ b/src/CodexUsageWidget/Views/SettingsWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="CodexUsageWidget.Views.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Settings"
+        xmlns:localization="clr-namespace:CodexUsageWidget.Views.Localization"
+        Title="{localization:Loc Common_Settings}"
         Width="468"
         Height="700"
         ResizeMode="NoResize"
@@ -248,11 +249,11 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <StackPanel>
-                    <TextBlock Text="Settings"
+                    <TextBlock Text="{localization:Loc Common_Settings}"
                                FontSize="20"
                                FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimary}" />
-                    <TextBlock Text="Choose how Codex Usage Widget looks and behaves."
+                    <TextBlock Text="{localization:Loc Settings_Description}"
                                Margin="0,3,0,0"
                                Style="{StaticResource SupportingText}" />
                 </StackPanel>
@@ -261,7 +262,7 @@
                         Height="28"
                         Margin="12,-4,-4,0"
                         VerticalAlignment="Top"
-                        ToolTip="Close"
+                        ToolTip="{localization:Loc Common_Close}"
                         IsCancel="True"
                         Style="{StaticResource IconButton}">
                     <Path Width="10"
@@ -282,16 +283,16 @@
                           Style="{StaticResource SlimScrollViewer}">
               <StackPanel Margin="0,0,5,0">
                 <StackPanel>
-                    <TextBlock Text="GENERAL" Style="{StaticResource SectionTitle}" />
+                    <TextBlock Text="{localization:Loc Settings_SectionGeneral}" Style="{StaticResource SectionTitle}" />
                     <CheckBox x:Name="StartWithWindowsOption"
                               Margin="0,14,0,0"
-                              AutomationProperties.Name="Start with Windows"
+                              AutomationProperties.Name="{localization:Loc Settings_StartWithWindows}"
                               Checked="StartWithWindowsOption_OnChanged"
                               Unchecked="StartWithWindowsOption_OnChanged"
                               Style="{StaticResource SettingsToggleCard}">
                         <StackPanel VerticalAlignment="Center">
-                            <TextBlock Text="Start with Windows" FontWeight="SemiBold" />
-                            <TextBlock Text="Launch the widget when you sign in"
+                            <TextBlock Text="{localization:Loc Settings_StartWithWindows}" FontWeight="SemiBold" />
+                            <TextBlock Text="{localization:Loc Settings_StartWithWindowsDescription}"
                                        Margin="0,3,0,0"
                                        Style="{StaticResource SupportingText}" />
                         </StackPanel>
@@ -299,11 +300,61 @@
                 </StackPanel>
 
                 <StackPanel Margin="0,18,0,14">
-                    <TextBlock Text="Theme"
+                    <TextBlock Text="{localization:Loc Settings_Language_Title}"
                                FontSize="15"
                                FontWeight="SemiBold"
                                Foreground="{DynamicResource TextPrimary}" />
-                    <TextBlock Text="Use the Windows setting or keep the widget in one theme."
+                    <TextBlock Text="{localization:Loc Settings_Language_Description}"
+                               Margin="0,3,0,0"
+                               TextWrapping="Wrap"
+                               Style="{StaticResource SupportingText}" />
+                </StackPanel>
+
+                <StackPanel>
+                    <RadioButton x:Name="SystemLanguageOption"
+                                 GroupName="Language"
+                                 AutomationProperties.Name="{localization:Loc Settings_Language_SystemAutomation}"
+                                 Checked="LanguageOption_OnChecked"
+                                 Style="{StaticResource SettingsOptionCard}">
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{localization:Loc Settings_Language_System}" FontWeight="SemiBold" />
+                            <TextBlock Text="{localization:Loc Settings_Language_SystemDescription}"
+                                       Margin="0,3,0,0"
+                                       Style="{StaticResource SupportingText}" />
+                        </StackPanel>
+                    </RadioButton>
+                    <RadioButton x:Name="EnglishLanguageOption"
+                                 GroupName="Language"
+                                 AutomationProperties.Name="{localization:Loc Settings_Language_EnglishAutomation}"
+                                 Checked="LanguageOption_OnChecked"
+                                 Style="{StaticResource SettingsOptionCard}">
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{localization:Loc Settings_Language_English}" FontWeight="SemiBold" />
+                            <TextBlock Text="{localization:Loc Settings_Language_EnglishDescription}"
+                                       Margin="0,3,0,0"
+                                       Style="{StaticResource SupportingText}" />
+                        </StackPanel>
+                    </RadioButton>
+                    <RadioButton x:Name="SimplifiedChineseLanguageOption"
+                                 GroupName="Language"
+                                 AutomationProperties.Name="{localization:Loc Settings_Language_ChineseAutomation}"
+                                 Checked="LanguageOption_OnChecked"
+                                 Style="{StaticResource SettingsOptionCard}">
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{localization:Loc Settings_Language_Chinese}" FontWeight="SemiBold" />
+                            <TextBlock Text="{localization:Loc Settings_Language_ChineseDescription}"
+                                       Margin="0,3,0,0"
+                                       Style="{StaticResource SupportingText}" />
+                        </StackPanel>
+                    </RadioButton>
+                </StackPanel>
+
+                <StackPanel Margin="0,18,0,14">
+                    <TextBlock Text="{localization:Loc Settings_Theme_Title}"
+                               FontSize="15"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextPrimary}" />
+                    <TextBlock Text="{localization:Loc Settings_Theme_Description}"
                                Margin="0,3,0,0"
                                Style="{StaticResource SupportingText}" />
                 </StackPanel>
@@ -311,7 +362,7 @@
               <StackPanel>
                 <RadioButton x:Name="SystemThemeOption"
                              GroupName="Theme"
-                             AutomationProperties.Name="Use Windows theme"
+                             AutomationProperties.Name="{localization:Loc Settings_Theme_SystemAutomation}"
                              Checked="ThemeOption_OnChecked"
                              Style="{StaticResource SettingsOptionCard}">
                     <Grid>
@@ -320,8 +371,8 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <StackPanel VerticalAlignment="Center">
-                            <TextBlock Text="Use Windows setting" FontWeight="SemiBold" />
-                            <TextBlock Text="Changes with your Windows app theme"
+                            <TextBlock Text="{localization:Loc Settings_Theme_System}" FontWeight="SemiBold" />
+                            <TextBlock Text="{localization:Loc Settings_Theme_SystemDescription}"
                                        Margin="0,3,0,0"
                                        Style="{StaticResource SupportingText}" />
                         </StackPanel>
@@ -346,7 +397,7 @@
 
                 <RadioButton x:Name="LightThemeOption"
                              GroupName="Theme"
-                             AutomationProperties.Name="Use light theme"
+                             AutomationProperties.Name="{localization:Loc Settings_Theme_LightAutomation}"
                              Checked="ThemeOption_OnChecked"
                              Style="{StaticResource SettingsOptionCard}">
                     <Grid>
@@ -355,8 +406,8 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <StackPanel VerticalAlignment="Center">
-                            <TextBlock Text="Light" FontWeight="SemiBold" />
-                            <TextBlock Text="Bright surfaces with dark text"
+                            <TextBlock Text="{localization:Loc Settings_Theme_Light}" FontWeight="SemiBold" />
+                            <TextBlock Text="{localization:Loc Settings_Theme_LightDescription}"
                                        Margin="0,3,0,0"
                                        Style="{StaticResource SupportingText}" />
                         </StackPanel>
@@ -377,7 +428,7 @@
 
                 <RadioButton x:Name="DarkThemeOption"
                              GroupName="Theme"
-                             AutomationProperties.Name="Use dark theme"
+                             AutomationProperties.Name="{localization:Loc Settings_Theme_DarkAutomation}"
                              Checked="ThemeOption_OnChecked"
                              Style="{StaticResource SettingsOptionCard}">
                     <Grid>
@@ -386,8 +437,8 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <StackPanel VerticalAlignment="Center">
-                            <TextBlock Text="Dark" FontWeight="SemiBold" />
-                            <TextBlock Text="Dark surfaces with light text"
+                            <TextBlock Text="{localization:Loc Settings_Theme_Dark}" FontWeight="SemiBold" />
+                            <TextBlock Text="{localization:Loc Settings_Theme_DarkDescription}"
                                        Margin="0,3,0,0"
                                        Style="{StaticResource SupportingText}" />
                         </StackPanel>
@@ -412,42 +463,42 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock VerticalAlignment="Center"
-                               Text="Accent"
+                               Text="{localization:Loc Settings_Accent_Title}"
                                Style="{StaticResource SupportingText}" />
                     <StackPanel Grid.Column="1" Orientation="Horizontal">
                         <RadioButton x:Name="BlueAccentOption"
                                      GroupName="AccentPalette"
                                      Background="#3B78D8"
-                                     ToolTip="Blue"
-                                     AutomationProperties.Name="Use blue accent"
+                                     ToolTip="{localization:Loc Settings_Accent_Blue}"
+                                     AutomationProperties.Name="{localization:Loc Settings_Accent_BlueAutomation}"
                                      Checked="AccentPaletteOption_OnChecked"
                                      Style="{StaticResource AccentSwatchOption}" />
                         <RadioButton x:Name="VioletAccentOption"
                                      GroupName="AccentPalette"
                                      Background="#7C3AED"
-                                     ToolTip="Violet"
-                                     AutomationProperties.Name="Use violet accent"
+                                     ToolTip="{localization:Loc Settings_Accent_Violet}"
+                                     AutomationProperties.Name="{localization:Loc Settings_Accent_VioletAutomation}"
                                      Checked="AccentPaletteOption_OnChecked"
                                      Style="{StaticResource AccentSwatchOption}" />
                         <RadioButton x:Name="TealAccentOption"
                                      GroupName="AccentPalette"
                                      Background="#0F8F83"
-                                     ToolTip="Teal"
-                                     AutomationProperties.Name="Use teal accent"
+                                     ToolTip="{localization:Loc Settings_Accent_Teal}"
+                                     AutomationProperties.Name="{localization:Loc Settings_Accent_TealAutomation}"
                                      Checked="AccentPaletteOption_OnChecked"
                                      Style="{StaticResource AccentSwatchOption}" />
                         <RadioButton x:Name="EmeraldAccentOption"
                                      GroupName="AccentPalette"
                                      Background="#1D9148"
-                                     ToolTip="Emerald"
-                                     AutomationProperties.Name="Use emerald accent"
+                                     ToolTip="{localization:Loc Settings_Accent_Emerald}"
+                                     AutomationProperties.Name="{localization:Loc Settings_Accent_EmeraldAutomation}"
                                      Checked="AccentPaletteOption_OnChecked"
                                      Style="{StaticResource AccentSwatchOption}" />
                         <RadioButton x:Name="PinkAccentOption"
                                      GroupName="AccentPalette"
                                      Background="#C72F75"
-                                     ToolTip="Pink"
-                                     AutomationProperties.Name="Use pink accent"
+                                     ToolTip="{localization:Loc Settings_Accent_Pink}"
+                                     AutomationProperties.Name="{localization:Loc Settings_Accent_PinkAutomation}"
                                      Checked="AccentPaletteOption_OnChecked"
                                      Style="{StaticResource AccentSwatchOption}" />
                     </StackPanel>
@@ -455,11 +506,11 @@
               </StackPanel>
 
               <StackPanel Margin="0,10,0,14">
-                  <TextBlock Text="Widget layout"
+                  <TextBlock Text="{localization:Loc Settings_Layout_Title}"
                              FontSize="15"
                              FontWeight="SemiBold"
                              Foreground="{DynamicResource TextPrimary}" />
-                  <TextBlock Text="Choose how much information the desktop widget shows."
+                  <TextBlock Text="{localization:Loc Settings_Layout_Description}"
                              Margin="0,3,0,0"
                              Style="{StaticResource SupportingText}" />
               </StackPanel>
@@ -472,12 +523,12 @@
                   <RadioButton x:Name="CompactLayoutOption"
                                GroupName="WidgetLayout"
                                Margin="0,0,4,8"
-                               AutomationProperties.Name="Use compact widget layout"
+                               AutomationProperties.Name="{localization:Loc Settings_Layout_CompactAutomation}"
                                Checked="WidgetLayoutOption_OnChecked"
                                Style="{StaticResource SettingsOptionCard}">
                       <StackPanel VerticalAlignment="Center">
-                          <TextBlock Text="Compact" FontWeight="SemiBold" />
-                          <TextBlock Text="Summary at a glance"
+                          <TextBlock Text="{localization:Loc Settings_Layout_Compact}" FontWeight="SemiBold" />
+                          <TextBlock Text="{localization:Loc Settings_Layout_CompactDescription}"
                                      Margin="0,3,0,0"
                                      Style="{StaticResource SupportingText}" />
                       </StackPanel>
@@ -486,12 +537,12 @@
                                Grid.Column="1"
                                GroupName="WidgetLayout"
                                Margin="4,0,0,8"
-                               AutomationProperties.Name="Use detailed widget layout"
+                               AutomationProperties.Name="{localization:Loc Settings_Layout_DetailedAutomation}"
                                Checked="WidgetLayoutOption_OnChecked"
                                Style="{StaticResource SettingsOptionCard}">
                       <StackPanel VerticalAlignment="Center">
-                          <TextBlock Text="Detailed" FontWeight="SemiBold" />
-                          <TextBlock Text="Full usage breakdown"
+                          <TextBlock Text="{localization:Loc Settings_Layout_Detailed}" FontWeight="SemiBold" />
+                          <TextBlock Text="{localization:Loc Settings_Layout_DetailedDescription}"
                                      Margin="0,3,0,0"
                                      Style="{StaticResource SupportingText}" />
                       </StackPanel>
@@ -503,13 +554,13 @@
                       Background="{DynamicResource DividerBrush}" />
 
               <StackPanel Margin="0,0,0,14">
-                  <TextBlock Text="USAGE" Style="{StaticResource SectionTitle}" />
-                  <TextBlock Text="Displayed limit"
+                  <TextBlock Text="{localization:Loc Settings_SectionUsage}" Style="{StaticResource SectionTitle}" />
+                  <TextBlock Text="{localization:Loc Settings_DisplayedLimit_Title}"
                              Margin="0,8,0,0"
                              FontSize="15"
                              FontWeight="SemiBold"
                              Foreground="{DynamicResource TextPrimary}" />
-                  <TextBlock Text="Choose the limit shown in the widget, taskbar label, and tray icon."
+                  <TextBlock Text="{localization:Loc Settings_DisplayedLimit_Description}"
                              Margin="0,3,0,0"
                              TextWrapping="Wrap"
                              Style="{StaticResource SupportingText}" />
@@ -518,13 +569,13 @@
               <StackPanel>
                   <RadioButton x:Name="FiveHourLimitOption"
                                GroupName="DisplayedLimit"
-                               AutomationProperties.Name="Display 5-hour limit"
+                               AutomationProperties.Name="{localization:Loc Settings_DisplayedLimit_FiveHourAutomation}"
                                Checked="DisplayedLimitOption_OnChecked"
                                Style="{StaticResource SettingsOptionCard}"
-                               ToolTip="Codex did not return a global 5h limit for this account.">
+                               ToolTip="{localization:Loc Settings_DisplayedLimit_FiveHourUnavailable}">
                       <StackPanel VerticalAlignment="Center">
-                          <TextBlock Text="5h limit" FontWeight="SemiBold" />
-                          <TextBlock Text="Show the global five-hour usage window"
+                          <TextBlock Text="{localization:Loc Usage_FiveHourLimit}" FontWeight="SemiBold" />
+                          <TextBlock Text="{localization:Loc Settings_DisplayedLimit_FiveHourDescription}"
                                      Margin="0,3,0,0"
                                      Style="{StaticResource SupportingText}" />
                       </StackPanel>
@@ -532,12 +583,12 @@
 
                   <RadioButton x:Name="WeeklyLimitOption"
                                GroupName="DisplayedLimit"
-                               AutomationProperties.Name="Display weekly limit"
+                               AutomationProperties.Name="{localization:Loc Settings_DisplayedLimit_WeeklyAutomation}"
                                Checked="DisplayedLimitOption_OnChecked"
                                Style="{StaticResource SettingsOptionCard}">
                       <StackPanel VerticalAlignment="Center">
-                          <TextBlock Text="Weekly limit" FontWeight="SemiBold" />
-                          <TextBlock Text="Show the global weekly usage window"
+                          <TextBlock Text="{localization:Loc Usage_WeeklyLimit}" FontWeight="SemiBold" />
+                          <TextBlock Text="{localization:Loc Settings_DisplayedLimit_WeeklyDescription}"
                                      Margin="0,3,0,0"
                                      Style="{StaticResource SupportingText}" />
                       </StackPanel>
@@ -545,12 +596,12 @@
 
                   <RadioButton x:Name="MostConstrainedLimitOption"
                                GroupName="DisplayedLimit"
-                               AutomationProperties.Name="Display most constrained limit"
+                               AutomationProperties.Name="{localization:Loc Settings_DisplayedLimit_MostConstrainedAutomation}"
                                Checked="DisplayedLimitOption_OnChecked"
                                Style="{StaticResource SettingsOptionCard}">
                       <StackPanel VerticalAlignment="Center">
-                          <TextBlock Text="Most constrained" FontWeight="SemiBold" />
-                          <TextBlock Text="Show whichever available limit has the least remaining"
+                          <TextBlock Text="{localization:Loc Settings_DisplayedLimit_MostConstrained}" FontWeight="SemiBold" />
+                          <TextBlock Text="{localization:Loc Settings_DisplayedLimit_MostConstrainedDescription}"
                                      Margin="0,3,0,0"
                                      Style="{StaticResource SupportingText}" />
                       </StackPanel>
@@ -562,7 +613,7 @@
                       Background="{DynamicResource DividerBrush}" />
 
               <StackPanel x:Name="ActivityDotsSection">
-                  <TextBlock Text="FEATURES" Style="{StaticResource SectionTitle}" />
+                  <TextBlock Text="{localization:Loc Settings_SectionFeatures}" Style="{StaticResource SectionTitle}" />
                   <ContentControl x:Name="ActivityDotsHost" Margin="0,14,0,0" />
               </StackPanel>
              </StackPanel>

--- a/src/CodexUsageWidget/Views/SettingsWindow.xaml.cs
+++ b/src/CodexUsageWidget/Views/SettingsWindow.xaml.cs
@@ -22,6 +22,7 @@ public partial class SettingsWindow : Window
         IActivityHookSetupService activityHookSetupService,
         ICodexLauncher codexLauncher,
         AccentPalette accentPalette = AccentPalette.Blue,
+        LanguagePreference languagePreference = LanguagePreference.System,
         IWindowWorkAreaProvider? workAreaProvider = null)
     {
         _workAreaProvider = workAreaProvider ?? new WindowWorkAreaProvider();
@@ -36,6 +37,7 @@ public partial class SettingsWindow : Window
         SetDisplayedLimitPreference(displayedLimitPreference);
         SetFiveHourLimitAvailability(fiveHourLimitAvailable);
         SetStartWithWindowsEnabled(startWithWindowsEnabled);
+        SetLanguagePreference(languagePreference);
         _suppressChangeEvents = false;
     }
 
@@ -48,6 +50,8 @@ public partial class SettingsWindow : Window
     public event Action<DisplayedLimitPreference>? DisplayedLimitPreferenceChanged;
 
     public event Action<bool>? StartWithWindowsChanged;
+
+    public event Action<LanguagePreference>? LanguagePreferenceChanged;
 
     public ThemePreference SelectedTheme =>
         LightThemeOption.IsChecked == true
@@ -80,6 +84,13 @@ public partial class SettingsWindow : Window
             : WidgetDensity.Compact;
 
     public bool StartWithWindowsEnabled => StartWithWindowsOption.IsChecked == true;
+
+    public LanguagePreference SelectedLanguage =>
+        EnglishLanguageOption.IsChecked == true
+            ? LanguagePreference.English
+            : SimplifiedChineseLanguageOption.IsChecked == true
+                ? LanguagePreference.SimplifiedChinese
+                : LanguagePreference.System;
 
     protected override void OnSourceInitialized(EventArgs e)
     {
@@ -126,6 +137,17 @@ public partial class SettingsWindow : Window
         var previousSuppression = _suppressChangeEvents;
         _suppressChangeEvents = true;
         StartWithWindowsOption.IsChecked = enabled;
+        _suppressChangeEvents = previousSuppression;
+    }
+
+    public void SetLanguagePreference(LanguagePreference preference)
+    {
+        var previousSuppression = _suppressChangeEvents;
+        _suppressChangeEvents = true;
+        SystemLanguageOption.IsChecked = preference == LanguagePreference.System;
+        EnglishLanguageOption.IsChecked = preference == LanguagePreference.English;
+        SimplifiedChineseLanguageOption.IsChecked =
+            preference == LanguagePreference.SimplifiedChinese;
         _suppressChangeEvents = previousSuppression;
     }
 
@@ -190,6 +212,14 @@ public partial class SettingsWindow : Window
         if (!_suppressChangeEvents)
         {
             StartWithWindowsChanged?.Invoke(StartWithWindowsEnabled);
+        }
+    }
+
+    private void LanguageOption_OnChecked(object sender, RoutedEventArgs e)
+    {
+        if (!_suppressChangeEvents)
+        {
+            LanguagePreferenceChanged?.Invoke(SelectedLanguage);
         }
     }
 }

--- a/src/CodexUsageWidget/Views/TaskbarLabelWindow.xaml
+++ b/src/CodexUsageWidget/Views/TaskbarLabelWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:controls="clr-namespace:CodexUsageWidget.Views.Controls"
+        xmlns:localization="clr-namespace:CodexUsageWidget.Views.Localization"
         Width="102"
         Height="40"
         WindowStyle="None"
@@ -55,20 +56,20 @@
                            TargetType="Separator"
                            BasedOn="{StaticResource TaskbarContextMenuSeparator}" />
                 </ContextMenu.Resources>
-                <MenuItem Header="Open widget" Click="OpenMenuItem_OnClick">
+                <MenuItem Header="{localization:Loc Taskbar_OpenWidget}" Click="OpenMenuItem_OnClick">
                     <MenuItem.Icon>
                         <Path Data="M 2.5,3.5 H 13.5 V 12.5 H 2.5 Z M 2.5,6 H 13.5"
                               Style="{StaticResource TaskbarMenuIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Refresh" Click="RefreshMenuItem_OnClick">
+                <MenuItem Header="{localization:Loc Common_Refresh}" Click="RefreshMenuItem_OnClick">
                     <MenuItem.Icon>
                         <Path Data="M 13.5,5.5 V 2.5 M 13.5,2.5 H 10.5 M 13,7 A 5.5,5.5 0 1 0 13,10.5"
                               Style="{StaticResource TaskbarMenuIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem x:Name="ActivityPreviewMenuItem"
-                          Header="Preview activity animation"
+                          Header="{localization:Loc Taskbar_PreviewActivity}"
                           IsCheckable="True"
                           Visibility="Collapsed"
                           Click="ActivityPreviewMenuItem_OnClick">
@@ -77,27 +78,27 @@
                               Style="{StaticResource TaskbarMenuIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Settings..." Click="SettingsMenuItem_OnClick">
+                <MenuItem Header="{localization:Loc Tray_Settings}" Click="SettingsMenuItem_OnClick">
                     <MenuItem.Icon>
                         <Path Data="M 8,5.2 A 2.8,2.8 0 1 0 8,10.8 A 2.8,2.8 0 1 0 8,5.2 M 8,2 V 3.3 M 8,12.7 V 14 M 2,8 H 3.3 M 12.7,8 H 14 M 3.8,3.8 L 4.8,4.8 M 11.2,11.2 L 12.2,12.2 M 12.2,3.8 L 11.2,4.8 M 4.8,11.2 L 3.8,12.2"
                               Style="{StaticResource TaskbarMenuIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <Separator />
-                <MenuItem Header="Use desktop widget" Click="DesktopModeMenuItem_OnClick">
+                <MenuItem Header="{localization:Loc Taskbar_UseDesktopWidget}" Click="DesktopModeMenuItem_OnClick">
                     <MenuItem.Icon>
                         <Path Data="M 2,3.5 H 14 V 11 H 2 Z M 6,13.5 H 10 M 8,11 V 13.5"
                               Style="{StaticResource TaskbarMenuIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="Check for updates..." Click="CheckForUpdatesMenuItem_OnClick">
+                <MenuItem Header="{localization:Loc Tray_CheckUpdates}" Click="CheckForUpdatesMenuItem_OnClick">
                     <MenuItem.Icon>
                         <Path Data="M 6,3 H 13 V 10 M 13,3 L 5,11 M 10,13 H 3 V 6"
                               Style="{StaticResource TaskbarMenuIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <Separator />
-                <MenuItem Header="Exit" Click="ExitMenuItem_OnClick">
+                <MenuItem Header="{localization:Loc Common_Exit}" Click="ExitMenuItem_OnClick">
                     <MenuItem.Icon>
                         <Path Data="M 6,3 H 3 V 13 H 6 M 9.5,5 L 12.5,8 L 9.5,11 M 12.5,8 H 6"
                               Style="{StaticResource TaskbarMenuIcon}" />

--- a/src/CodexUsageWidget/Views/TaskbarLabelWindow.xaml.cs
+++ b/src/CodexUsageWidget/Views/TaskbarLabelWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using CodexUsageWidget.Infrastructure.Settings;
 using CodexUsageWidget.Infrastructure.Windows;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Views;
 
@@ -18,6 +19,9 @@ public partial class TaskbarLabelWindow : Window
     private readonly WindowChangeWatcher _windowChangeWatcher;
     private ExternalMouseDownWatcher? _contextMenuDismissWatcher;
     private IntPtr _windowHandle;
+    private string? _limitLabel;
+    private double? _remainingPercent;
+    private DateTimeOffset? _resetsAt;
     private bool _labelRequested;
     private bool _isTaskActive;
     private bool _isClosed;
@@ -27,6 +31,7 @@ public partial class TaskbarLabelWindow : Window
     public TaskbarLabelWindow()
     {
         InitializeComponent();
+        Strings.Current.PropertyChanged += StringsOnPropertyChanged;
 
 #if DEBUG || ACTIVITY_PREVIEW
         ActivityPreviewMenuItem.Visibility = Visibility.Visible;
@@ -54,6 +59,7 @@ public partial class TaskbarLabelWindow : Window
             _contextMenuDismissWatcher?.Dispose();
             _contextMenuDismissWatcher = null;
             _windowChangeWatcher.Dispose();
+            Strings.Current.PropertyChanged -= StringsOnPropertyChanged;
         };
     }
 
@@ -162,19 +168,36 @@ public partial class TaskbarLabelWindow : Window
         double? remainingPercent,
         DateTimeOffset? resetsAt)
     {
+        _limitLabel = limitLabel;
+        _remainingPercent = remainingPercent;
+        _resetsAt = resetsAt;
         if (remainingPercent is null)
         {
             UsageText.Text = "--%";
-            LabelSurface.ToolTip = "Codex usage is currently unavailable.";
+            LabelSurface.ToolTip = Strings.Get("Taskbar_UsageUnavailable");
             return;
         }
 
         var value = Math.Round(Math.Clamp(remainingPercent.Value, 0d, 100d));
         UsageText.Text = $"{value:0}%";
-        var label = string.IsNullOrWhiteSpace(limitLabel) ? "Codex" : limitLabel;
+        var label = string.IsNullOrWhiteSpace(limitLabel)
+            ? "Codex"
+            : UsageLabelLocalizer.Localize(limitLabel);
         LabelSurface.ToolTip = resetsAt is null
-            ? $"{label}: {value:0}% remaining"
-            : $"{label}: {value:0}% remaining · resets {resetsAt.Value:ddd HH:mm}";
+            ? Strings.Format("Taskbar_Remaining", label, value)
+            : Strings.Format(
+                "Taskbar_RemainingWithReset",
+                label,
+                value,
+                resetsAt.Value.ToString("ddd HH:mm", System.Globalization.CultureInfo.CurrentCulture));
+    }
+
+    private void StringsOnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == "Item[]" && !_isClosed)
+        {
+            UpdateUsage(_limitLabel, _remainingPercent, _resetsAt);
+        }
     }
 
     private void Reposition()

--- a/src/CodexUsageWidget/Views/ViewModels/ActivityHookSetupViewModel.cs
+++ b/src/CodexUsageWidget/Views/ViewModels/ActivityHookSetupViewModel.cs
@@ -1,5 +1,6 @@
 using System.Windows.Media;
 using CodexUsageWidget.Application;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Views.ViewModels;
 
@@ -9,10 +10,10 @@ public sealed class ActivityHookSetupViewModel
     {
     }
 
-    public string StatusLabel { get; private init; } = "Checking Codex…";
+    public string StatusLabel { get; private init; } = Strings.Get("Activity_Checking");
 
     public string Description { get; private init; } =
-        "Reading the local hook configuration and Codex trust status.";
+        Strings.Get("Activity_CheckingDescription");
 
     public System.Windows.Media.Brush StatusBrush { get; private init; } =
         BrushFromHex("#D6A15F");
@@ -25,9 +26,9 @@ public sealed class ActivityHookSetupViewModel
 
     public bool CanRefresh { get; private init; }
 
-    public string CodexActionLabel { get; private init; } = "Open in Codex";
+    public string CodexActionLabel { get; private init; } = Strings.Get("Activity_OpenInCodex");
 
-    public string InstallActionLabel { get; private init; } = "Review hooks";
+    public string InstallActionLabel { get; private init; } = Strings.Get("Activity_ReviewHooks");
 
     public static ActivityHookSetupViewModel Loading() => new();
 
@@ -36,80 +37,76 @@ public sealed class ActivityHookSetupViewModel
         {
             ActivityHookSetupState.NotInstalled => new ActivityHookSetupViewModel
             {
-                StatusLabel = "Setup required",
-                Description =
-                    "Install three local lifecycle hooks to animate the taskbar dots while Codex works. " +
-                    "You can review the exact hooks.json change before it is written.",
+                StatusLabel = Strings.Get("Activity_SetupRequired"),
+                Description = Strings.Get("Activity_SetupRequiredDescription"),
                 StatusBrush = BrushFromHex("#D6A15F"),
                 CanInstall = true,
                 CanRefresh = true
             },
             ActivityHookSetupState.UpdateRequired => new ActivityHookSetupViewModel
             {
-                StatusLabel = "Update available",
-                Description =
-                    "Activity handlers from an older widget version are installed. " +
-                    "Update them to the faster, path-independent bridge after reviewing the exact change.",
+                StatusLabel = Strings.Get("Activity_UpdateAvailable"),
+                Description = Strings.Get("Activity_UpdateDescription"),
                 StatusBrush = BrushFromHex("#D6A15F"),
-                InstallActionLabel = "Review update",
+                InstallActionLabel = Strings.Get("Activity_ReviewUpdate"),
                 CanInstall = true,
                 CanUninstall = true,
                 CanRefresh = true
             },
             ActivityHookSetupState.ApprovalRequired => new ActivityHookSetupViewModel
             {
-                StatusLabel = "One step left",
-                Description =
-                    "Hooks are installed. Approve their exact definitions once in Codex before they can run.",
+                StatusLabel = Strings.Get("Activity_OneStepLeft"),
+                Description = Strings.Get("Activity_ApprovalDescription"),
                 StatusBrush = BrushFromHex("#D6A15F"),
-                CodexActionLabel = "Approve in Codex",
+                CodexActionLabel = Strings.Get("Activity_ApproveInCodex"),
                 CanOpenCodex = true,
                 CanUninstall = true,
                 CanRefresh = true
             },
             ActivityHookSetupState.Active => new ActivityHookSetupViewModel
             {
-                StatusLabel = "Activity dots are ready",
-                Description = "All three hooks are installed and trusted.",
+                StatusLabel = Strings.Get("Activity_Ready"),
+                Description = Strings.Get("Activity_ReadyDescription"),
                 StatusBrush = BrushFromHex("#68B88A"),
                 CanUninstall = true,
                 CanRefresh = true
             },
             ActivityHookSetupState.Modified => new ActivityHookSetupViewModel
             {
-                StatusLabel = "Review required",
-                Description =
-                    "Codex paused the changed definitions. Review them again before activity reporting resumes.",
+                StatusLabel = Strings.Get("Activity_ReviewRequired"),
+                Description = Strings.Get("Activity_ModifiedDescription"),
                 StatusBrush = BrushFromHex("#D6A15F"),
-                CodexActionLabel = "Review in Codex",
+                CodexActionLabel = Strings.Get("Activity_ReviewInCodex"),
                 CanOpenCodex = true,
                 CanUninstall = true,
                 CanRefresh = true
             },
             ActivityHookSetupState.HooksDisabled => new ActivityHookSetupViewModel
             {
-                StatusLabel = "Hooks are disabled in Codex",
-                Description = status.Detail ??
-                    "Set hooks = true in the [features] section of your Codex config before installing.",
+                StatusLabel = Strings.Get("Activity_HooksDisabled"),
+                Description = Strings.Get("Activity_HooksDisabledDescription"),
                 StatusBrush = BrushFromHex("#E16D76"),
                 CanUninstall = status.HasInstalledHandlers,
                 CanRefresh = true
             },
             ActivityHookSetupState.InstalledStatusUnavailable => new ActivityHookSetupViewModel
             {
-                StatusLabel = "Installed · status unavailable",
-                Description = status.Detail ??
-                    "Hooks are installed, but their trust status could not be verified.",
+                StatusLabel = Strings.Get("Activity_StatusUnavailable"),
+                Description = status.Detail is null
+                    ? Strings.Get("Activity_StatusUnavailableDescription")
+                    : Strings.Format("Activity_StatusUnavailableWithDetail", status.Detail),
                 StatusBrush = BrushFromHex("#D6A15F"),
-                CodexActionLabel = "Open hooks in Codex",
+                CodexActionLabel = Strings.Get("Activity_OpenHooksInCodex"),
                 CanOpenCodex = true,
                 CanUninstall = true,
                 CanRefresh = true
             },
             _ => new ActivityHookSetupViewModel
             {
-                StatusLabel = "Setup unavailable",
-                Description = status.Detail ?? "The activity hook configuration could not be read.",
+                StatusLabel = Strings.Get("Activity_SetupUnavailable"),
+                Description = status.Detail is null
+                    ? Strings.Get("Activity_SetupUnavailableDescription")
+                    : Strings.Format("Activity_SetupErrorDetail", status.Detail),
                 StatusBrush = BrushFromHex("#E16D76"),
                 CanRefresh = true
             }
@@ -117,7 +114,7 @@ public sealed class ActivityHookSetupViewModel
 
     public static ActivityHookSetupViewModel Error(string message) => new()
     {
-        StatusLabel = "Setup unavailable",
+        StatusLabel = Strings.Get("Activity_SetupUnavailable"),
         Description = message,
         StatusBrush = BrushFromHex("#E16D76"),
         CanRefresh = true

--- a/src/CodexUsageWidget/Views/ViewModels/TokenActivityViewModel.cs
+++ b/src/CodexUsageWidget/Views/ViewModels/TokenActivityViewModel.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using CodexUsageWidget.Domain;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Views.ViewModels;
 
@@ -22,25 +23,25 @@ public sealed class TokenActivityViewModel
     private static List<DetailMetricViewModel> BuildMetrics(TokenActivitySummary activity)
     {
         var metrics = new List<DetailMetricViewModel>();
-        AddMetric(metrics, "Lifetime tokens", FormatNumber(activity.LifetimeTokens));
-        AddMetric(metrics, "Peak daily tokens", FormatNumber(activity.PeakDailyTokens));
+        AddMetric(metrics, Strings.Get("Token_Lifetime"), FormatNumber(activity.LifetimeTokens));
+        AddMetric(metrics, Strings.Get("Token_PeakDaily"), FormatNumber(activity.PeakDailyTokens));
         AddMetric(
             metrics,
-            "Longest turn",
+            Strings.Get("Token_LongestTurn"),
             activity.LongestRunningTurnSeconds is { } seconds
                 ? FormatDuration(seconds)
                 : null);
         AddMetric(
             metrics,
-            "Current streak",
+            Strings.Get("Token_CurrentStreak"),
             activity.CurrentStreakDays is { } currentStreak
-                ? $"{currentStreak:N0} days"
+                ? Strings.Format("Token_Days", currentStreak.ToString("N0", CultureInfo.CurrentCulture))
                 : null);
         AddMetric(
             metrics,
-            "Longest streak",
+            Strings.Get("Token_LongestStreak"),
             activity.LongestStreakDays is { } longestStreak
-                ? $"{longestStreak:N0} days"
+                ? Strings.Format("Token_Days", longestStreak.ToString("N0", CultureInfo.CurrentCulture))
                 : null);
         return metrics;
     }
@@ -59,8 +60,10 @@ public sealed class TokenActivityViewModel
             .Select(item => new DailyUsageBarViewModel(
                 Math.Max(3d, 44d * item.Tokens / maximum),
                 item.Date.ToString("dddd, MMMM d", CultureInfo.CurrentCulture),
-                $"{item.Tokens.ToString("N0", CultureInfo.CurrentCulture)} tokens",
-                $"{100d * item.Tokens / maximum:0}% of chart peak"))
+                Strings.Format(
+                    "Token_Count",
+                    item.Tokens.ToString("N0", CultureInfo.CurrentCulture)),
+                Strings.Format("Token_ChartPeak", Math.Round(100d * item.Tokens / maximum))))
             .ToArray();
     }
 
@@ -83,7 +86,12 @@ public sealed class TokenActivityViewModel
     {
         var duration = TimeSpan.FromSeconds(Math.Max(0, seconds));
         return duration.TotalHours >= 1
-            ? $"{(int)duration.TotalHours}h {duration.Minutes}m"
-            : $"{Math.Max(1, (int)Math.Ceiling(duration.TotalMinutes))}m";
+            ? Strings.Format(
+                "Token_DurationHoursMinutes",
+                (int)duration.TotalHours,
+                duration.Minutes)
+            : Strings.Format(
+                "Token_DurationMinutes",
+                Math.Max(1, (int)Math.Ceiling(duration.TotalMinutes)));
     }
 }

--- a/src/CodexUsageWidget/Views/ViewModels/UsageLimitViewModel.cs
+++ b/src/CodexUsageWidget/Views/ViewModels/UsageLimitViewModel.cs
@@ -1,6 +1,7 @@
 using System.Windows.Media;
 using CodexUsageWidget.Application;
 using CodexUsageWidget.Domain;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Views.ViewModels;
 
@@ -11,11 +12,13 @@ public sealed class UsageLimitViewModel
         Label = label;
         UsedPercent = window.UsedPercent;
         IsNormal = window.RemainingPercent > 25;
-        UsedText = $"{Math.Round(window.UsedPercent):0}% used";
-        RemainingText = $"{Math.Round(window.RemainingPercent):0}% remaining";
+        UsedText = Strings.Format("Usage_UsedPercent", Math.Round(window.UsedPercent));
+        RemainingText = Strings.Format(
+            "Usage_RemainingPercent",
+            Math.Round(window.RemainingPercent));
         ResetText = window.ResetsAt is null
-            ? "Reset time unavailable"
-            : $"Resets {UsageTextFormatter.FormatReset(window.ResetsAt.Value)}";
+            ? Strings.Get("Usage_ResetUnavailable")
+            : UsageTextFormatter.FormatReset(window.ResetsAt.Value);
         ProgressBrush = new SolidColorBrush(
             (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(
                 UsageTextFormatter.ColorForRemaining(window.RemainingPercent)));

--- a/src/CodexUsageWidget/Views/ViewModels/UsageWidgetViewModel.cs
+++ b/src/CodexUsageWidget/Views/ViewModels/UsageWidgetViewModel.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Windows.Media;
 using CodexUsageWidget.Domain;
+using CodexUsageWidget.Localization;
 
 namespace CodexUsageWidget.Views.ViewModels;
 
@@ -10,15 +11,15 @@ public sealed class UsageWidgetViewModel
     {
     }
 
-    public string StatusText { get; private init; } = "Connecting…";
+    public string StatusText { get; private init; } = Strings.Get("Status_Connecting");
 
     public System.Windows.Media.Brush StatusBrush { get; private init; } = BrushFromHex("#D6A15F");
 
     public string HeadlineRemainingText { get; private init; } = "--%";
 
-    public string HeadlineLabel { get; private init; } = "Waiting for Codex";
+    public string HeadlineLabel { get; private init; } = Strings.Get("Status_WaitingForCodex");
 
-    public string UpdatedText { get; private init; } = "Local only · waiting for sync";
+    public string UpdatedText { get; private init; } = Strings.Get("Status_LocalWaiting");
 
     public string? WarningText { get; private init; }
 
@@ -45,22 +46,22 @@ public sealed class UsageWidgetViewModel
 
     public DateTimeOffset? HeadlineResetsAt { get; private init; }
 
-    public static UsageWidgetViewModel Loading(string updatedText = "Local only · waiting for sync") => new()
+    public static UsageWidgetViewModel Loading(string? updatedText = null) => new()
     {
-        UpdatedText = updatedText
+        UpdatedText = updatedText ?? Strings.Get("Status_LocalWaiting")
     };
 
     public static UsageWidgetViewModel Error(string message) => new()
     {
-        StatusText = "Offline",
+        StatusText = Strings.Get("Status_Offline"),
         StatusBrush = BrushFromHex("#E16D76"),
         HeadlineLabel = message,
-        UpdatedText = "Local only · select refresh to retry"
+        UpdatedText = Strings.Get("Status_LocalRetry")
     };
 
     public UsageWidgetViewModel Syncing() => new()
     {
-        StatusText = "Syncing…",
+        StatusText = Strings.Get("Status_Syncing"),
         StatusBrush = BrushFromHex("#D6A15F"),
         HeadlineRemainingText = HeadlineRemainingText,
         HeadlineLabel = HeadlineLabel,
@@ -81,7 +82,7 @@ public sealed class UsageWidgetViewModel
         var generalLimits = BuildLimitViewModels(snapshot.GeneralLimits, includeBucketLabel: false);
         if (generalLimits.Length == 0 || displayedWindow is not { } displayed)
         {
-            return Error("No subscription limits returned. Run codex login first.");
+            return Error(Strings.Get("Status_NoLimits"));
         }
 
         var modelLimits = BuildLimitViewModels(
@@ -91,13 +92,17 @@ public sealed class UsageWidgetViewModel
 
         return new UsageWidgetViewModel
         {
-            StatusText = plan is null ? "Live · ChatGPT" : $"Live · {plan}",
+            StatusText = Strings.Format("Status_LivePlan", plan ?? "ChatGPT"),
             StatusBrush = BrushFromHex("#68B88A"),
             HeadlineRemainingText = $"{Math.Round(displayed.RemainingPercent):0}%",
-            HeadlineLabel = $"{displayed.Label} remaining",
+            HeadlineLabel = Strings.Format(
+                "Status_HeadlineRemaining",
+                UsageLabelLocalizer.Localize(displayed.Label)),
             HeadlineRemainingPercent = displayed.RemainingPercent,
             HeadlineResetsAt = displayed.ResetsAt,
-            UpdatedText = $"Local only · updated {snapshot.FetchedAt:HH:mm:ss}",
+            UpdatedText = Strings.Format(
+                "Status_LocalUpdated",
+                snapshot.FetchedAt.ToString("HH:mm:ss", CultureInfo.CurrentCulture)),
             WarningText = BuildWarning(snapshot.RateLimits.Limits),
             GeneralLimits = generalLimits,
             ModelLimits = modelLimits,
@@ -112,7 +117,9 @@ public sealed class UsageWidgetViewModel
         IEnumerable<UsageLimitBucket> limits,
         bool includeBucketLabel) => limits
         .SelectMany(limit => limit.Windows.Select(window => new UsageLimitViewModel(
-            includeBucketLabel ? $"{limit.Label} · {window.Label}" : window.Label,
+            includeBucketLabel
+                ? $"{limit.Label} · {UsageLabelLocalizer.Localize(window.Label)}"
+                : UsageLabelLocalizer.Localize(window.Label),
             window)))
         .ToArray();
 
@@ -125,29 +132,36 @@ public sealed class UsageWidgetViewModel
         if (general?.Credits is { } credits)
         {
             var value = credits.Unlimited
-                ? "Unlimited"
+                ? Strings.Get("Common_Unlimited")
                 : !string.IsNullOrWhiteSpace(credits.Balance)
-                    ? $"{credits.Balance} remaining"
-                    : credits.HasCredits ? "Available" : "None available";
-            metrics.Add(new DetailMetricViewModel("ChatGPT credits", value));
+                    ? Strings.Format("Usage_CreditsRemaining", credits.Balance)
+                    : credits.HasCredits
+                        ? Strings.Get("Common_Available")
+                        : Strings.Get("Common_NoneAvailable");
+            metrics.Add(new DetailMetricViewModel(Strings.Get("Usage_ChatGptCredits"), value));
         }
 
         if (general?.IndividualLimit is { } spendLimit)
         {
             metrics.Add(new DetailMetricViewModel(
-                "Individual spend limit",
-                $"{spendLimit.Used} of {spendLimit.Limit} · " +
-                $"{Math.Round(spendLimit.RemainingPercent):0}% remaining"));
+                Strings.Get("Usage_IndividualSpendLimit"),
+                Strings.Format(
+                    "Usage_SpendLimitValue",
+                    spendLimit.Used,
+                    spendLimit.Limit,
+                    Math.Round(spendLimit.RemainingPercent))));
             metrics.Add(new DetailMetricViewModel(
-                "Spend limit resets",
+                Strings.Get("Usage_SpendLimitResets"),
                 spendLimit.ResetsAt.ToString("ddd HH:mm", CultureInfo.CurrentCulture)));
         }
 
         if (rateLimits.ResetCredits is { } resetCredits)
         {
             metrics.Add(new DetailMetricViewModel(
-                "Rate-limit resets",
-                $"{resetCredits.AvailableCount:N0} available"));
+                Strings.Get("Usage_RateLimitResets"),
+                Strings.Format(
+                    "Usage_CountAvailable",
+                    resetCredits.AvailableCount.ToString("N0", CultureInfo.CurrentCulture))));
         }
 
         return metrics;
@@ -161,15 +175,15 @@ public sealed class UsageWidgetViewModel
             return reachedState switch
             {
                 "workspace_owner_credits_depleted" or "workspace_member_credits_depleted" =>
-                    "Workspace credits are depleted.",
+                    Strings.Get("Warning_WorkspaceCreditsDepleted"),
                 "workspace_owner_usage_limit_reached" or "workspace_member_usage_limit_reached" =>
-                    "Workspace usage limit reached.",
-                _ => "Codex usage limit reached."
+                    Strings.Get("Warning_WorkspaceUsageLimitReached"),
+                _ => Strings.Get("Warning_UsageLimitReached")
             };
         }
 
         return limits.Any(limit => limit.SpendControlReached == true)
-            ? "Individual spend control reached."
+            ? Strings.Get("Warning_SpendControlReached")
             : null;
     }
 

--- a/tests/CodexUsageWidget.Tests/AppLanguageControllerTests.cs
+++ b/tests/CodexUsageWidget.Tests/AppLanguageControllerTests.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
+using CodexUsageWidget.Domain;
 using CodexUsageWidget.Infrastructure.Settings;
 using CodexUsageWidget.Localization;
+using CodexUsageWidget.Views.ViewModels;
 
 namespace CodexUsageWidget.Tests;
 
@@ -41,6 +43,27 @@ public sealed class AppLanguageControllerTests : IDisposable
         {
             languageChanged |= e.PropertyName == "Item[]";
         }
+    }
+
+    [Fact]
+    public void ManualPreferenceFormatsVisibleDatesUsingSelectedLanguage()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+        var controller = new AppLanguageController(
+            LanguagePreference.SimplifiedChinese,
+            CultureInfo.GetCultureInfo("en-US"));
+        var date = new DateOnly(2026, 8, 11);
+        var activity = new TokenActivitySummary(
+            LifetimeTokens: null,
+            PeakDailyTokens: null,
+            LongestRunningTurnSeconds: null,
+            CurrentStreakDays: null,
+            LongestStreakDays: null,
+            DailyUsage: [new DailyTokenUsage(date, 50_000)]);
+
+        var viewModel = new TokenActivityViewModel(activity);
+
+        Assert.Equal("星期二, 八月 11", viewModel.DailyBars[0].DateText);
     }
 
     public void Dispose()

--- a/tests/CodexUsageWidget.Tests/AppLanguageControllerTests.cs
+++ b/tests/CodexUsageWidget.Tests/AppLanguageControllerTests.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using CodexUsageWidget.Infrastructure.Settings;
+using CodexUsageWidget.Localization;
+
+namespace CodexUsageWidget.Tests;
+
+[Collection("Localization")]
+public sealed class AppLanguageControllerTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "CodexUsageWidget.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ManualPreferenceUpdatesCultureAndPersistsOverride()
+    {
+        var store = new LanguagePreferenceStore(Path.Combine(_directory, "language.txt"));
+        var controller = new AppLanguageController(
+            store,
+            CultureInfo.GetCultureInfo("zh-CN"));
+        var languageChanged = false;
+        Strings.Current.PropertyChanged += OnLanguageChanged;
+        try
+        {
+            Assert.Equal(LanguagePreference.System, controller.Preference);
+            Assert.Equal("zh-CN", Strings.Current.Culture.Name);
+
+            controller.SetPreference(LanguagePreference.English);
+
+            Assert.True(languageChanged);
+            Assert.Equal("en-US", Strings.Current.Culture.Name);
+            Assert.Equal(LanguagePreference.English, store.Load());
+        }
+        finally
+        {
+            Strings.Current.PropertyChanged -= OnLanguageChanged;
+        }
+
+        void OnLanguageChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            languageChanged |= e.PropertyName == "Item[]";
+        }
+    }
+
+    public void Dispose()
+    {
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo("en-US"));
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+}
+
+[CollectionDefinition("Localization", DisableParallelization = true)]
+public sealed class LocalizationCollectionDefinition;

--- a/tests/CodexUsageWidget.Tests/CodexActivityCommandLineTests.cs
+++ b/tests/CodexUsageWidget.Tests/CodexActivityCommandLineTests.cs
@@ -1,0 +1,139 @@
+using System.Globalization;
+using CodexUsageWidget.Infrastructure.Codex.Hooks;
+using CodexUsageWidget.Localization;
+
+namespace CodexUsageWidget.Tests;
+
+[Collection("Localization")]
+public sealed class CodexActivityCommandLineTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "CodexUsageWidget.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task UninstallWithoutMatchingHooksUsesSelectedLanguage()
+    {
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo("zh-CN"));
+        var output = new StringWriter(CultureInfo.InvariantCulture);
+        var manager = new CodexHookConfigurationManager(
+            Path.Combine(_directory, "hooks.json"),
+            Path.Combine(_directory, "config.toml"));
+
+        var exitCode = await CodexActivityCommandLine.RunInteractiveAsync(
+            ["--uninstall-activity-hooks"],
+            TextReader.Null,
+            output,
+            manager);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("未找到已安装的匹配活动钩子。", output.ToString().Trim());
+    }
+
+    [Fact]
+    public async Task DeclinedInstallUsesSelectedLanguage()
+    {
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo("zh-CN"));
+        var output = new StringWriter(CultureInfo.InvariantCulture);
+        var manager = new CodexHookConfigurationManager(
+            Path.Combine(_directory, "hooks.json"),
+            Path.Combine(_directory, "config.toml"));
+
+        var exitCode = await CodexActivityCommandLine.RunInteractiveAsync(
+            ["--install-activity-hooks"],
+            new StringReader("n"),
+            output,
+            manager);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("拟写入的 ~/.codex/hooks.json：", output.ToString(), StringComparison.Ordinal);
+        Assert.Contains("应用此更改？[y/N] ", output.ToString(), StringComparison.Ordinal);
+        Assert.EndsWith("未进行任何更改。", output.ToString().Trim(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SuccessfulInstallUsesSelectedLanguage()
+    {
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo("zh-CN"));
+        var output = new StringWriter(CultureInfo.InvariantCulture);
+        var hooksPath = Path.Combine(_directory, "hooks.json");
+        var manager = new CodexHookConfigurationManager(
+            hooksPath,
+            Path.Combine(_directory, "config.toml"));
+
+        var exitCode = await CodexActivityCommandLine.RunInteractiveAsync(
+            ["--install-activity-hooks"],
+            new StringReader("y"),
+            output,
+            manager);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(hooksPath));
+        Assert.EndsWith(
+            "活动钩子已安装。请使用 /hooks 检查并信任确切定义。",
+            output.ToString().Trim(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SuccessfulUninstallUsesSelectedLanguage()
+    {
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo("zh-CN"));
+        var output = new StringWriter(CultureInfo.InvariantCulture);
+        var manager = new CodexHookConfigurationManager(
+            Path.Combine(_directory, "hooks.json"),
+            Path.Combine(_directory, "config.toml"));
+        await CodexActivityCommandLine.RunInteractiveAsync(
+            ["--install-activity-hooks"],
+            new StringReader("y"),
+            output,
+            manager);
+        output.GetStringBuilder().Clear();
+
+        var exitCode = await CodexActivityCommandLine.RunInteractiveAsync(
+            ["--uninstall-activity-hooks"],
+            new StringReader("y"),
+            output,
+            manager);
+
+        Assert.Equal(0, exitCode);
+        Assert.EndsWith(
+            "已移除匹配的活动钩子。",
+            output.ToString().Trim(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DisabledHooksErrorUsesSelectedLanguage()
+    {
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo("zh-CN"));
+        Directory.CreateDirectory(_directory);
+        var configPath = Path.Combine(_directory, "config.toml");
+        await File.WriteAllTextAsync(configPath, "[features]\nhooks = false\n");
+        var output = new StringWriter(CultureInfo.InvariantCulture);
+        var manager = new CodexHookConfigurationManager(
+            Path.Combine(_directory, "hooks.json"),
+            configPath);
+
+        var exitCode = await CodexActivityCommandLine.RunInteractiveAsync(
+            ["--install-activity-hooks"],
+            TextReader.Null,
+            output,
+            manager);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(
+            "安装前，请在 Codex 配置的 [features] 部分设置 hooks = true。",
+            output.ToString().Trim());
+    }
+
+    public void Dispose()
+    {
+        Strings.Current.SetCulture(CultureInfo.GetCultureInfo("en-US"));
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+}

--- a/tests/CodexUsageWidget.Tests/LanguagePreferenceResolverTests.cs
+++ b/tests/CodexUsageWidget.Tests/LanguagePreferenceResolverTests.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using CodexUsageWidget.Infrastructure.Settings;
+
+namespace CodexUsageWidget.Tests;
+
+public sealed class LanguagePreferenceResolverTests
+{
+    [Theory]
+    [InlineData("en-US", LanguagePreference.English)]
+    [InlineData("fr-FR", LanguagePreference.English)]
+    [InlineData("zh-TW", LanguagePreference.English)]
+    [InlineData("zh-HK", LanguagePreference.English)]
+    [InlineData("zh-MO", LanguagePreference.English)]
+    [InlineData("zh-Hant", LanguagePreference.English)]
+    [InlineData("zh-CN", LanguagePreference.SimplifiedChinese)]
+    [InlineData("zh-SG", LanguagePreference.SimplifiedChinese)]
+    [InlineData("zh-Hans", LanguagePreference.SimplifiedChinese)]
+    public void ResolveSystemUsesSupportedWindowsCultureOrEnglishFallback(
+        string cultureName,
+        LanguagePreference expected)
+    {
+        Assert.Equal(
+            expected,
+            LanguagePreferenceResolver.Resolve(
+                LanguagePreference.System,
+                CultureInfo.GetCultureInfo(cultureName)));
+    }
+
+    [Theory]
+    [InlineData(LanguagePreference.English, "zh-CN")]
+    [InlineData(LanguagePreference.SimplifiedChinese, "en-US")]
+    public void ResolveExplicitPreferenceOverridesWindowsCulture(
+        LanguagePreference preference,
+        string cultureName)
+    {
+        Assert.Equal(
+            preference,
+            LanguagePreferenceResolver.Resolve(
+                preference,
+                CultureInfo.GetCultureInfo(cultureName)));
+    }
+}

--- a/tests/CodexUsageWidget.Tests/LanguagePreferenceStoreTests.cs
+++ b/tests/CodexUsageWidget.Tests/LanguagePreferenceStoreTests.cs
@@ -1,0 +1,70 @@
+using CodexUsageWidget.Infrastructure.Settings;
+
+namespace CodexUsageWidget.Tests;
+
+public sealed class LanguagePreferenceStoreTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "CodexUsageWidget.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void LoadUsesSystemWhenPreferenceDoesNotExist()
+    {
+        var store = new LanguagePreferenceStore(Path.Combine(_directory, "language.txt"));
+
+        Assert.Equal(LanguagePreference.System, store.Load());
+    }
+
+    [Theory]
+    [InlineData("system", LanguagePreference.System)]
+    [InlineData("english", LanguagePreference.English)]
+    [InlineData("simplified-chinese", LanguagePreference.SimplifiedChinese)]
+    [InlineData("SIMPLIFIED-CHINESE", LanguagePreference.SimplifiedChinese)]
+    [InlineData("unknown", LanguagePreference.System)]
+    public void LoadParsesStableValueOrFallsBackToSystem(
+        string value,
+        LanguagePreference expected)
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(Path.Combine(_directory, "language.txt"), value);
+        var store = new LanguagePreferenceStore(Path.Combine(_directory, "language.txt"));
+
+        Assert.Equal(expected, store.Load());
+    }
+
+    [Theory]
+    [InlineData(LanguagePreference.System, "system")]
+    [InlineData(LanguagePreference.English, "english")]
+    [InlineData(LanguagePreference.SimplifiedChinese, "simplified-chinese")]
+    public void SavePersistsStablePreferenceValue(
+        LanguagePreference preference,
+        string expectedValue)
+    {
+        var path = Path.Combine(_directory, "language.txt");
+        var store = new LanguagePreferenceStore(path);
+
+        store.Save(preference);
+
+        Assert.Equal(expectedValue, File.ReadAllText(path));
+        Assert.Equal(preference, store.Load());
+    }
+
+    [Fact]
+    public void LoadUsesSystemWhenPreferenceCannotBeRead()
+    {
+        Directory.CreateDirectory(_directory);
+        var store = new LanguagePreferenceStore(_directory);
+
+        Assert.Equal(LanguagePreference.System, store.Load());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+}

--- a/tests/CodexUsageWidget.Tests/LocalizationResourceTests.cs
+++ b/tests/CodexUsageWidget.Tests/LocalizationResourceTests.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Globalization;
+using System.Resources;
+using System.Text.RegularExpressions;
+using CodexUsageWidget.Localization;
+
+namespace CodexUsageWidget.Tests;
+
+public sealed partial class LocalizationResourceTests
+{
+    private static readonly ResourceManager Resources = new(
+        "CodexUsageWidget.Resources.Strings",
+        typeof(Strings).Assembly);
+
+    [Fact]
+    public void EnglishAndSimplifiedChineseHaveMatchingKeysAndPlaceholders()
+    {
+        var english = ReadResources(CultureInfo.InvariantCulture);
+        var chinese = ReadResources(CultureInfo.GetCultureInfo("zh-CN"));
+
+        Assert.Equal(english.Keys.Order(), chinese.Keys.Order());
+        foreach (var key in english.Keys)
+        {
+            Assert.Equal(
+                ReadPlaceholders(english[key]),
+                ReadPlaceholders(chinese[key]));
+        }
+    }
+
+    [Fact]
+    public void ResourceManagerUsesChineseAndFallsBackToEnglish()
+    {
+        Assert.Equal(
+            "设置",
+            Resources.GetString("Common_Settings", CultureInfo.GetCultureInfo("zh-CN")));
+        Assert.Equal(
+            "Settings",
+            Resources.GetString("Common_Settings", CultureInfo.GetCultureInfo("fr-FR")));
+    }
+
+    private static Dictionary<string, string> ReadResources(CultureInfo culture)
+    {
+        var resourceSet = Resources.GetResourceSet(
+            culture,
+            createIfNotExists: true,
+            tryParents: false)!;
+        return resourceSet.Cast<DictionaryEntry>().ToDictionary(
+            entry => (string)entry.Key,
+            entry => (string)entry.Value!);
+    }
+
+    private static string[] ReadPlaceholders(string value) => PlaceholderRegex()
+        .Matches(value)
+        .Select(match => match.Groups[1].Value)
+        .Distinct(StringComparer.Ordinal)
+        .Order(StringComparer.Ordinal)
+        .ToArray();
+
+    [GeneratedRegex(@"\{(\d+)(?:[^}]*)\}")]
+    private static partial Regex PlaceholderRegex();
+}

--- a/tests/CodexUsageWidget.Tests/TaskbarSettingsMenuTests.cs
+++ b/tests/CodexUsageWidget.Tests/TaskbarSettingsMenuTests.cs
@@ -1,14 +1,17 @@
+using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Windows.Controls;
 using System.Windows.Media;
 using CodexUsageWidget.Application;
 using CodexUsageWidget.Infrastructure.Settings;
 using CodexUsageWidget.Infrastructure.Windows;
+using CodexUsageWidget.Localization;
 using CodexUsageWidget.Views;
 using CodexUsageWidget.Views.Controls;
 
 namespace CodexUsageWidget.Tests;
 
+[Collection("Localization")]
 public sealed class TaskbarSettingsMenuTests
 {
     [Fact]
@@ -19,7 +22,9 @@ public sealed class TaskbarSettingsMenuTests
         {
             try
             {
-                var application = new App();
+                var application = new App(new AppLanguageController(
+                    LanguagePreference.English,
+                    CultureInfo.GetCultureInfo("en-US")));
                 application.InitializeComponent();
                 var themeTestDirectory = Path.Combine(
                     Path.GetTempPath(),
@@ -128,6 +133,16 @@ public sealed class TaskbarSettingsMenuTests
                     codexLauncher: new StubCodexLauncher(),
                     accentPalette: AccentPalette.Violet);
                 Assert.NotNull(usageSettings.FindName("ActivityDotsSection"));
+                var systemLanguageOption = Assert.IsType<RadioButton>(
+                    usageSettings.FindName("SystemLanguageOption"));
+                Assert.True(systemLanguageOption.IsChecked);
+                LanguagePreference? changedLanguage = null;
+                usageSettings.LanguagePreferenceChanged += preference =>
+                    changedLanguage = preference;
+                var chineseLanguageOption = Assert.IsType<RadioButton>(
+                    usageSettings.FindName("SimplifiedChineseLanguageOption"));
+                chineseLanguageOption.IsChecked = true;
+                Assert.Equal(LanguagePreference.SimplifiedChinese, changedLanguage);
                 var activityDotsHost = Assert.IsType<ContentControl>(
                     usageSettings.FindName("ActivityDotsHost"));
                 Assert.IsType<ActivityHookSetupControl>(activityDotsHost.Content);
@@ -259,6 +274,15 @@ public sealed class TaskbarSettingsMenuTests
         if (failure is not null)
         {
             ExceptionDispatchInfo.Capture(failure).Throw();
+        }
+
+        try
+        {
+            Strings.Current.SetCulture(CultureInfo.GetCultureInfo("zh-CN"));
+        }
+        finally
+        {
+            Strings.Current.SetCulture(CultureInfo.GetCultureInfo("en-US"));
         }
     }
 

--- a/tests/CodexUsageWidget.Tests/UsageLabelLocalizerTests.cs
+++ b/tests/CodexUsageWidget.Tests/UsageLabelLocalizerTests.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using CodexUsageWidget.Localization;
+
+namespace CodexUsageWidget.Tests;
+
+public sealed class UsageLabelLocalizerTests
+{
+    [Theory]
+    [InlineData("Weekly limit", "每周限制")]
+    [InlineData("1d limit", "1 天限制")]
+    [InlineData("6h limit", "6 小时限制")]
+    [InlineData("30m limit", "30 分钟限制")]
+    [InlineData("Primary limit", "主要限制")]
+    [InlineData("Secondary limit", "次要限制")]
+    [InlineData("GPT-5.3-Codex", "GPT-5.3-Codex")]
+    public void LocalizeUsesChineseForKnownPresentationLabels(
+        string label,
+        string expected) => Assert.Equal(
+            expected,
+            UsageLabelLocalizer.Localize(label, CultureInfo.GetCultureInfo("zh-CN")));
+}

--- a/tests/CodexUsageWidget.Tests/UsageTextFormatterTests.cs
+++ b/tests/CodexUsageWidget.Tests/UsageTextFormatterTests.cs
@@ -18,7 +18,7 @@ public sealed class UsageTextFormatterTests
 
         var result = UsageTextFormatter.FormatReset(reset, now);
 
-        Assert.Equal("in 3h · 12:10", result);
+        Assert.Equal("Resets in 3h · 12:10", result);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- extract user-facing text into standard .NET localization resources
- add complete Simplified Chinese (`zh-CN`) resources with English fallback
- detect the Windows UI language and support System, English, and Simplified Chinese preferences
- persist manual language overrides in Settings
- refresh the widget, Settings, tray, taskbar, activity-hook, tooltip, accessibility, status, error, and update UI at runtime
- keep existing numeric and date formatting semantics unchanged
- add resource parity, culture resolution, persistence, runtime switching, and regression tests

No third-party localization dependencies were added.

<img width="472" height="355" alt="image" src="https://github.com/user-attachments/assets/512be0e5-5c7d-4d69-9184-54db5ffc3981" />
<img width="487" height="777" alt="image" src="https://github.com/user-attachments/assets/c187d2dd-91d0-423d-868e-d6385f643996" />
<img width="610" height="905" alt="image" src="https://github.com/user-attachments/assets/a89cac12-2945-424c-8424-311bf8f3353f" />

## Testing

- `dotnet restore .\CodexUsageWidget.slnx`
- `dotnet build .\CodexUsageWidget.slnx -c Release --no-restore`
- `dotnet test .\CodexUsageWidget.slnx -c Release --no-build` (157 tests passed)
- manually verified English, Simplified Chinese, runtime switching, persistence, and Windows UI layout

Closes #4
